### PR TITLE
Fix for string subsetting example

### DIFF
--- a/strings.Rmd
+++ b/strings.Rmd
@@ -126,7 +126,7 @@ str_c(c("x", "y", "z"), collapse = ", ")
 You can extract parts of a string using `str_sub()`. As well as the string, `str_sub()` takes `start` and `end` argument which give the (inclusive) position of the substring:
 
 ```{r}
-x <- c("apple", "banana", "pear")
+x <- c("Apple", "Banana", "Pear")
 str_sub(x, 1, 3)
 # negative numbers count backwards from end
 str_sub(x, -3, -1)


### PR DESCRIPTION
Words in example vector `x <- c("apple", "banana", "pear")` should start with an uppercase letter so the `str_to_lower` example makes sense.