### PR TITLE
Typo correction in file expressing-yourself.Rmd

### DIFF
--- a/expressing-yourself.Rmd
+++ b/expressing-yourself.Rmd
@@ -217,7 +217,7 @@ The pipe is a powerful tool, but it's not the only tool at your disposal, and it
 
 ## Duplication
 
-As you become a better R programming, you'll learn more techniques for reducing various types of duplication. This allows you to do more with less, and allows you to express yourself more clearly by taking advantage of powerful programming constructs.
+As you become a better R programmer, you'll learn more techniques for reducing various types of duplication. This allows you to do more with less, and allows you to express yourself more clearly by taking advantage of powerful programming constructs.
 
 Two main tools for reducing duplication are functions and for-loops. You tend to use for-loops less often in R than in other programming languages because R is a functional programming language. That means that you can extract out common patterns of for loops and put them in a function.
 
@@ -243,7 +243,7 @@ df$d <- (df$d - min(df$d, na.rm = TRUE)) /
   (max(df$d, na.rm = TRUE) - min(df$d, na.rm = TRUE))
 ```
 
-You might be able to puzzle out that this rescales each column to 0--1. Did you spot the mistake? I made an error when updating the code for `df$y`, and I forgot to change an `x` to a `y`. Extracting repeated code out into a function is a good idea because it helps make your code more understandable (because you can name the operation), and it prevents you from making this sort of update error.
+You might be able to puzzle out that this rescales each column to 0--1. Did you spot the mistake? I made an error when updating the code for `df$b`, and I forgot to change an `a` to a `b`. Extracting repeated code out into a function is a good idea because it helps make your code more understandable (because you can name the operation), and it prevents you from making this sort of update error.
 
 To write a function you need to first analyse the operation. How many inputs does it have?
 
@@ -275,7 +275,7 @@ rescale01 <- function(x) {
 }
 ```
 
-Always make sure you code works on a simple test case before creating the function!
+Always make sure your code works on a simple test case before creating the function!
 
 Now we can use that to simplify our original example:
 
@@ -304,7 +304,7 @@ for (i in 1:ncol(df)) {
 medians
 ```
 
-If you do this a lot, you'd probably pull make a function for it:
+If you do this a lot, you should probably make a function for it:
 
 ```{r}
 col_medians <- function(df) {


### PR DESCRIPTION
The discussion of the code in lines 236-243 was a little confusing with x and y so I proposed changing it to a and b. Not sure if that was just an error that crept in while rewriting and fiddling around with the sentence or a conscious decision from you.
Just corrected a couple of obvious typos apart from that. 