### PR TITLE
Change `*` to `$` in Anchors Section of strings.Rmd

### DIFF
--- a/strings.Rmd
+++ b/strings.Rmd
@@ -248,7 +248,7 @@ In this book, I'll write a regular expression like `\.` and the string that repr
 By default, regular expressions will match any part of a string. It's often useful to _anchor_ the regular expression so that it matches from the start or end of the string. You can use:
 
 * `^` to match the start of the string.
-* `*` to match the end of the string.
+* `$` to match the end of the string.
 
 ```{r}
 x <- c("apple", "banana", "pear")


### PR DESCRIPTION
I'm just learning regular expressions, but I think you meant to use $ instead of * in the second bullet point in the section titled Anchors in strings.Rmd.