### PR TITLE
caption of list subset image

### DIFF
--- a/lists.Rmd
+++ b/lists.Rmd
@@ -132,6 +132,7 @@ Or visually:
 ```{r, echo = FALSE, out.width = "75%"}
 knitr::include_graphics("diagrams/lists-subsetting.png")
 ```
+the caption on the bottom right should be a[[4]][[1]]
 
 ### Lists of condiments
 


### PR DESCRIPTION
the caption on the bottom right of the image describing list subsetting should be a[[4]][[1]]. It is currently the same as the bottom middle which gives a list output whereas this one unlists it.