### PR TITLE
Fix typo

### DIFF
--- a/strings.Rmd
+++ b/strings.Rmd
@@ -330,7 +330,7 @@ str_view(c("grey", "gray"), "gr(e|a)y")
 
 ### Repetition
 
-The next step up in power involves control how many times a pattern matches:
+The next step up in power involves control over how many times a pattern matches:
 
 * `?`: 0 or 1
 * `+`: 1 or more


### PR DESCRIPTION
Missing a word (e.g., over or of) here.