### PR TITLE
fixed "from" typo

### DIFF
--- a/transform.Rmd
+++ b/transform.Rmd
@@ -605,7 +605,7 @@ This focuses on the transformations, not what's being transformed, which makes t
 
 Behind the scenes, `x %>% f(y)` turns into `f(x, y)` so you can use it to rewrite multiple operations that you can read left-to-right, top-to-bottom. We'll use piping frequently from now on because it considerably improves the readability of code, and we'll come back to it in more detail in Chapter XYZ.
 
-Most of the packages you'll learn through this book have been designed to work with the pipe (tidyr, dplyr, stringr, purrr, ...). The only exception is ggplot2: it was developed considerably before the discovery of the pipe. Unfortunately the next iteration of ggplot2, ggvis, which does use the pipe, isn't ready from prime time yet. 
+Most of the packages you'll learn through this book have been designed to work with the pipe (tidyr, dplyr, stringr, purrr, ...). The only exception is ggplot2: it was developed considerably before the discovery of the pipe. Unfortunately the next iteration of ggplot2, ggvis, which does use the pipe, isn't ready for prime time yet. 
 
 ### Missing values
 


### PR DESCRIPTION
Changed "... isn't ready from prime time yet." at end of 5.7.1 to " isn't ready for prime time yet."