### PR TITLE
Minor grammar fix -- removed "type of"

### DIFF
--- a/iteration.Rmd
+++ b/iteration.Rmd
@@ -261,7 +261,7 @@ for (i in seq_along(means)) {
 str(output)
 ```
 
-But this type of is not very efficient because in each iteration, R has to copy all the data from the previous iterations. In technical terms you get "quadratic" ($O(n^2)$) behaviour which means that a loop with three times as many elements would take nine times ($3^2$) as long to run.
+But this is not very efficient because in each iteration, R has to copy all the data from the previous iterations. In technical terms you get "quadratic" ($O(n^2)$) behaviour which means that a loop with three times as many elements would take nine times ($3^2$) as long to run.
 
 A better solution to save the results in a list, and then combine into a single vector after the loop is done:
 


### PR DESCRIPTION
There was a missing word after "type of" -- potentially you meant "type of assignment." I removed "type of" to make it more concise.