### PR TITLE
Fix a typo: Should be `purrr` instead of `purr`

### DIFF
--- a/model-basics.Rmd
+++ b/model-basics.Rmd
@@ -155,7 +155,7 @@ summary(h)
 ### Exercises
 
 1.  What variables in `heights` do you expect to be most highly correlated with
-    income?  Use `cor()` plus `purr::map_dbl()` to check your guesses.
+    income?  Use `cor()` plus `purrr::map_dbl()` to check your guesses.
 
 1.  Correlation only summarises the linear relationship between two continuous
     variables. There are some famous drawbacks to the correlation. What


### PR DESCRIPTION
Also I guess one natural solution to this exercise would be 
```R
purrr::map_if(heights, is.numeric, ~ cor(.x, heights$income))
``` 
But it leads to some crazy outputs. And `cor` is missing a `na.rm` argument.

And I believe the `heights$id` variable should be either a string or a factor.