### PR TITLE
Move "only" closer to "simulated"

### DIFF
--- a/model-basics.Rmd
+++ b/model-basics.Rmd
@@ -4,7 +4,7 @@
 
 The goal of a model is to provide a simple low-dimensional summary of a dataset. In the context of this book we're going to use models to partition data into patterns and residuals. Strong patterns will hide subtler trends, so we'll use models to help peel back layers of structure as we explore a datasets.
 
-However, before we can start using models on interesting, real, datasets, you need to understand the basics of how models work. For that reason, this chapter of the book is unique because it only uses simulated datasets. These datasets are very simple, and not at all interesting, but they will help you understand the essence of modelling before you apply the same techniques to real data in the next chapter.
+However, before we can start using models on interesting, real, datasets, you need to understand the basics of how models work. For that reason, this chapter of the book is unique because it uses only simulated datasets. These datasets are very simple, and not at all interesting, but they will help you understand the essence of modelling before you apply the same techniques to real data in the next chapter.
 
 There are three parts to a model:
 


### PR DESCRIPTION
trivial change: To reduce the slim chance the reader initially thinks "only" is modifying "uses".