### PR TITLE
Change to avoid redundancy in sentence

### DIFF
--- a/explore.Rmd
+++ b/explore.Rmd
@@ -16,4 +16,4 @@ Visualisation alone is typically not enough, so in [data transformation] you'll 
   
 Finally, in [exploratory data analysis], you'll combine visualisation and  transformation with your curiosity and scepticism to ask and answer interesting questions about data.
 
-Modelling is an important part of the exploratory process, but you don't have the skills to effectively learn or apply it yet. We'll come back to modelling in [modelling](#model-intro), once you're better equipped with more data wrangling and programming tools.
+Modelling is an important part of the exploratory process, but you don't have the skills to effectively learn or apply it yet. We'll come back to it in [modelling](#model-intro), once you're better equipped with more data wrangling and programming tools.

--- a/visualize.Rmd
+++ b/visualize.Rmd
@@ -37,7 +37,7 @@ You can test your answer with the `mpg` dataset in ggplot2, or `ggplot2::mpg`:
 mpg
 ```
 
-The dataset contains observations collected by the EPA on 38 models of car. Among the variables in `mpg` are:
+The dataset contains observations collected by the EPA on 38 models of cars. Among the variables in `mpg` are:
 
 1. `displ`, a car's engine size, in litres.
 


### PR DESCRIPTION
Last sentence in EDA introduction reads "We'll come back to modelling in modelling" which sounds redundant, change first modelling to "it".

Also, 38 models of "cars" should be plural.