### PR TITLE
Fixed a reference to nchar(NA) and added examples

### DIFF
--- a/strings.Rmd
+++ b/strings.Rmd
@@ -14,6 +14,12 @@ In this chapter you'll use the stringr package to manipulate strings.
 library(stringr)
 ```
 
+It has intuitive function names that start with `str_`. The common `str_` prefix is particularly useful if you use RStudio, because typing `str_` will trigger autocomplete, allowing you to see all stringr functions:
+
+```{r, echo = FALSE}
+knitr::include_graphics("screenshots/stringr-autocomplete.png")
+```
+
 ## String basics
 
 In R, strings are stored in a character vector. You can create strings with either single quotes or double quotes: there is no difference in behaviour. I recommend always using `"`, unless you want to create a string that contains multiple `"`, in which case use `'`.
@@ -49,23 +55,13 @@ x
 
 ### String length
 
-Base R contains many functions to work with strings but we'll generally avoid them because they're inconsistent and hard to remember. Their behaviour is particularly inconsistent when it comes to missing values. For example, `nchar()`, which gives the length of a string, returns 2 for `NA` (instead of `NA`)
+The length of a string can be obtained with `str_length()`:
 
 ```{r}
-# Bug will be fixed in R 3.3.0
-nchar(NA)
-```
-
-Instead we'll use functions from stringr. These have more intuitive names, and all start with `str_`:
-
-```{r}
-str_length(NA)
-```
-
-The common `str_` prefix is particularly useful if you use RStudio, because typing `str_` will trigger autocomplete, allowing you to see all stringr functions:
-
-```{r, echo = FALSE}
-knitr::include_graphics("screenshots/stringr-autocomplete.png")
+str_length("abc xyz")
+str_length(c("abc", "xyz"))
+# If a string is NA its length is also NA
+str_length(c("abc", NA))
 ```
 
 ### Combining strings

--- a/strings.Rmd
+++ b/strings.Rmd
@@ -332,11 +332,21 @@ The next step up in power involves control over how many times a pattern matches
 * `{n,m}`: between n and m
 
 ```{r}
+x <- "1888 is the longest year in Roman numerals: MDCCCLXXXVIII"
+str_view(x, 'CC?')
+str_view(x, 'CC+')
+str_view(x, 'Z*LX*')
+str_view(x, 'C*LX*')
+str_view(x, 'C{2}')
+str_view(x, 'C{2,}')
+str_view(x, 'C{2,3}')
 ```
 
 By default these matches are "greedy": they will match the longest string possible. You can make them "lazy", matching the shortest string possible by putting a `?` after them. This is an advanced feature of regular expressions, but it's useful to know that it exists:
 
 ```{r}
+str_view(x, 'C{2,3}?')
+str_view(x, 'C[LX]+?')
 ```
 
 Note that the precedence of these operators is high, so you can write: `colou?r` to match either American or British spellings. That means most uses will need parentheses, like `bana(na)+` or `ba(na){2,}`.

--- a/strings.Rmd
+++ b/strings.Rmd
@@ -334,7 +334,7 @@ The next step up in power involves control over how many times a pattern matches
 ```{r}
 ```
 
-By default these matches are "greedy": they will match the longest string possible. You can make them "lazy", matching the shortest string possible by putting a `?` after them. This is an advanced feature of regular expressions, but it's useful to know that it exists.
+By default these matches are "greedy": they will match the longest string possible. You can make them "lazy", matching the shortest string possible by putting a `?` after them. This is an advanced feature of regular expressions, but it's useful to know that it exists:
 
 ```{r}
 ```

--- a/strings.Rmd
+++ b/strings.Rmd
@@ -334,7 +334,7 @@ The next step up in power involves control over how many times a pattern matches
 ```{r}
 ```
 
-By default these matches are "greedy": they will match the longest string possible. You can make them "lazy", matching the shortest string possible by putting a `?` after them. This is an advanced feature of regular expressions, but it's useful to know that it exists:
+By default these matches are "greedy": they will match the longest string possible. You can make them "lazy", matching the shortest string possible by putting a `?` after them. This is an advanced feature of regular expressions, but it's useful to know that it exists.
 
 ```{r}
 ```


### PR DESCRIPTION
- The reference to nchar(NA) giving 2 as output was removed (as it's not actual). The "str_*" autocompletion was moved at the beginning.
- Added some examples to the "Repetition" subsection .