### PR TITLE
Test rather than confirm hypotheses

### DIFF
--- a/intro.Rmd
+++ b/intro.Rmd
@@ -79,23 +79,23 @@ However, we strongly believe that it's best to master one tool at a time. You wi
 
 This book focuses exclusively on rectangular data: collections of values that are each associated with a variable and an observation. There are lots of datasets that do not naturally fit in this paradigm: images, sounds, trees, text. But rectangular data frames are extremely common in science and in industry and we believe that they're a great place to start your data science journey.
 
-### Hypothesis confirmation
+### Hypothesis testing
 
-It's possible to divide data analysis into two camps: hypothesis generation and hypothesis confirmation (sometimes called confirmatory analysis). The focus of this book is unabashedly on hypothesis generation, or data exploration. Here you'll look deeply at the data and, in combination with your subject knowledge, generate many interesting hypotheses to help explain why the data behaves the way it does. You evaluate the hypotheses informally, using your scepticism to challenge the data in multiple ways.
+It's possible to divide data analysis into two camps: hypothesis generation and hypothesis testing (sometimes called confirmatory analysis). The focus of this book is unabashedly on hypothesis generation, or data exploration. Here you'll look deeply at the data and, in combination with your subject knowledge, generate many interesting hypotheses to help explain why the data behaves the way it does. You evaluate the hypotheses informally, using your scepticism to challenge the data in multiple ways.
 
-The complement of hypothesis generation is hypothesis confirmation. Hypothesis confirmation is hard for two reasons:
+The complement of hypothesis generation is hypothesis testing. Hypothesis testing is hard for two reasons:
 
 1.  You need a precise mathematical model in order to generate falsifiable
     predictions. This often requires considerable statistical sophistication.
 
-1.  You can only use an observation once to confirm a hypothesis. As soon as
+1.  You can only use an observation once to test a hypothesis. As soon as
     you use it more than once you're back to doing exploratory analysis. 
-    This means to do hypothesis confirmation you need to "preregister" 
+    This means to do hypothesis testing you need to "preregister" 
     (write out in advance) your analysis plan, and not deviate from it
     even when you have seen the data. We'll talk a little about some 
     strategies you can use to make this easier in [modelling](#model-intro).
 
-It's common to think about modelling as a tool for hypothesis confirmation, and visualisation as a tool for hypothesis generation. But that's a false dichotomy: models are often used for exploration, and with a little care you can use visualisation for confirmation. The key difference is how often do you look at each observation: if you look only once, it's confirmation; if you look more than once, it's exploration.
+It's common to think about modelling as a tool for hypothesis testing, and visualisation as a tool for hypothesis generation. But that's a false dichotomy: models are often used for exploration, and with a little care you can use visualisation for testing. The key difference is how often do you look at each observation: if you look only once, it's testing; if you look more than once, it's exploration.
 
 ## Prerequisites
 
@@ -230,7 +230,7 @@ This book isn't just the product of Hadley and Garrett, but is the result of man
 
 * Genevera Allen for discussions about models, modelling, the statistical
   learning perspective, and the difference between hypothesis generation and 
-  hypothesis confirmation.
+  hypothesis testing.
 
 * Yihui Xie for his work on the [bookdown](https://github.com/rstudio/bookdown) 
   package, and for tirelessly responding to my feature requests.


### PR DESCRIPTION
While "confirmatory analysis" is a thing, focusing on hypothesis testing rather than hypothesis confirmation fits better with the mention of falsifiability.