### PR TITLE
Trivial typo in fun name

### DIFF
--- a/communicate-plots.Rmd
+++ b/communicate-plots.Rmd
@@ -503,7 +503,7 @@ It's also possible to control individual components of each theme, like the size
 
 ## Saving your plots
 
-There are two main ways to get your plots out of R and into your final write-up: `gsave()` and knitr. `ggsave()` will save the most recent plot to disk:
+There are two main ways to get your plots out of R and into your final write-up: `ggsave()` and knitr. `ggsave()` will save the most recent plot to disk:
 
 ```{r, fig.show = "none"}
 ggplot(mpg, aes(displ, hwy)) + geom_point()


### PR DESCRIPTION
Typo: `gsave()` -> `ggsave()`