### PR TITLE
Change options(dplyr to options(tibble

### DIFF
--- a/tibble.Rmd
+++ b/tibble.Rmd
@@ -90,7 +90,7 @@ nycflights13::flights %>%
 You can also control the default print behaviour by setting options:
 
 * `options(tibble.print_max = n, tibble.print_min = m)`: if more than `m`
-  rows, print only `n` rows. Use `options(dplyr.print_max = Inf)` to always
+  rows, print only `n` rows. Use `options(tibble.print_max = Inf)` to always
   show all rows.
 
 * Use `options(tibble.width = Inf)` to always print all columns, regardless


### PR DESCRIPTION
Changing `options(dplyr.print_max = Inf)` to `options(tibble.print_max = Inf)` for consistency, though both work.

`options(tibble.print_max = n)` does not work as expected (max output also the tibble.print_min = m) but presume this is an issue with tibble and not r4ds