### PR TITLE
Fix typo in section 12.3.1 (Gathering)

### DIFF
--- a/tidy.Rmd
+++ b/tidy.Rmd
@@ -125,7 +125,7 @@ Typically a dataset will only suffer from one of these problems; it'll only suff
 
 ### Gathering
 
-A common problem is a dataset where some of the column names are not names of variables, but _values_ of a variable. Take `table4a`: the column names `1991` and `2000` represent values of the `year` variable, and each row represents two observations, not one.
+A common problem is a dataset where some of the column names are not names of variables, but _values_ of a variable. Take `table4a`: the column names `1999` and `2000` represent values of the `year` variable, and each row represents two observations, not one.
 
 ```{r}
 table4a


### PR DESCRIPTION
The second column in `table4a` is `1999`, not `1991`.