### PR TITLE
Typo fix

### DIFF
--- a/model-basics.Rmd
+++ b/model-basics.Rmd
@@ -186,7 +186,7 @@ ggplot(sim1, aes(x, y)) +
   geom_abline(intercept = best$par[1], slope = best$par[2])
 ```
 
-Don't worry too much about the details of how `optim()` works. It's the intuition that's important here. If you have a function that defines the distance between a model and a dataset, an algorthim that can minimise that distance by modifying the parameters of the model, you can find the best model. The neat thing about this approach is that it will work for any family of models that you can write an equation for. 
+Don't worry too much about the details of how `optim()` works. It's the intuition that's important here. If you have a function that defines the distance between a model and a dataset, an algorithm that can minimise that distance by modifying the parameters of the model, you can find the best model. The neat thing about this approach is that it will work for any family of models that you can write an equation for. 
 
 There's one more approach that we can use for this model, because it's is a special case of a broader family: linear models. A linear model has the general form `y = a_1 + a_2 * x_1 + a_3 * x_2 + ... + a_n * x_(n - 1)`. So this simple model is equivalent to a general linear model where n is 2 and `x_1` is `x`. R has a tool specifically designed for fitting linear models called `lm()`. `lm()` has a special way to specify the model family: formulas. Formulas look like `y ~ x`, which `lm()` will translate to a function like `y = a_1 + a_2 * x`. We can fit the model and look at the output:
 

--- a/model-basics.Rmd
+++ b/model-basics.Rmd
@@ -694,8 +694,6 @@ nobs(mod)
 
 ## Other model families
 
-Pattern in variance, not just mean. Or other characteristics of distribution of residuals.
-
 This chapter has focussed exclusively on the class of linear models, which assume a relationship of the form `y = a_1 * x1 + a_2 * x2 + ... + a_n * xn`. Linear models additionally assume that the residuals have a normal distribution, which we haven't talked about. There are a large set of model classes that extend the linear model in various interesting ways. Some of them are:
 
 * __Generalised linear models__, e.g. `stats::glm()`. Linear models assume that


### PR DESCRIPTION
In model basics: Typo fix: algorthim to algorithm. Removal of possible stub line after Other model families section header. New to github - hopefully I'm doing this right.