### PR TITLE
Changed "three" to "two" for list of two

### DIFF
--- a/model-basics.Rmd
+++ b/model-basics.Rmd
@@ -6,7 +6,7 @@ The goal of a model is to provide a simple low-dimensional summary of a dataset.
 
 However, before we can start using models on interesting, real, datasets, you need to understand the basics of how models work. For that reason, this chapter of the book is unique because it uses only simulated datasets. These datasets are very simple, and not at all interesting, but they will help you understand the essence of modelling before you apply the same techniques to real data in the next chapter.
 
-There are three parts to a model:
+There are two parts to a model:
 
 1.  First, you define a __family of models__ that express a precise, but 
     generic, pattern that you want to capture. For example, the pattern 


### PR DESCRIPTION
Unless there is a forgotten third part to a model