### PR TITLE
Add `show.legend = FALSE` mentioned in exercise

### DIFF
--- a/visualize.Rmd
+++ b/visualize.Rmd
@@ -359,7 +359,8 @@ ggplot(data = mpg) +
     
 ggplot(data = mpg) +
   geom_smooth(
-    mapping = aes(x = displ, y = hwy, group = drv)
+    mapping = aes(x = displ, y = hwy, color = drv),
+    show.legend = FALSE
   )
 ```
 


### PR DESCRIPTION
The example wants to show different ways of producing the same plot (as done in the print version). One of the exercises refers to a `show.legend = FALSE` used previously. This change brings the parts back into harmony.