### PR TITLE
Adds a missing "the"

### DIFF
--- a/visualize.Rmd
+++ b/visualize.Rmd
@@ -540,7 +540,7 @@ This works because every geom has a default stat; and every stat has a default g
       )
     ```
     
-ggplot2 provides over 20 stats for you to use. Each stat is a function, so you can get help in usual way, e.g. `?stat_bin`. To see a complete list of stats, try the ggplot2 cheatsheet.
+ggplot2 provides over 20 stats for you to use. Each stat is a function, so you can get help in the usual way, e.g. `?stat_bin`. To see a complete list of stats, try the ggplot2 cheatsheet.
 
 ### Exercises
 


### PR DESCRIPTION
The following sentence is missing the bracketed word (i.e., "the"): "ggplot2 provides over 20 stats for you to use. Each stat is a function, so you can get help in [the] usual way"