### PR TITLE
Fix duplicate figures

### DIFF
--- a/visualize.Rmd
+++ b/visualize.Rmd
@@ -355,12 +355,10 @@ ggplot(data = mpg) +
   geom_smooth(mapping = aes(x = displ, y = hwy))
               
 ggplot(data = mpg) +
-  geom_smooth(mapping = aes(x = displ, y = hwy, group = drv))
+  geom_smooth(mapping = aes(x = displ, y = hwy, linetype = drv))
     
 ggplot(data = mpg) +
-  geom_smooth(
-    mapping = aes(x = displ, y = hwy, group = drv)
-  )
+  geom_smooth(mapping = aes(x = displ, y = hwy, group = drv))
 ```
 
 To display multiple geoms in the same plot, add multiple geom functions to `ggplot()`:


### PR DESCRIPTION
I don't see a reason to have two "group = drv" plots.
Probably the second one was meant to be "linetype = drv" (as corrected), in order to demonstrate the difference between showing (or not) the legend.