### PR TITLE
Keep the same "table of cut values" example

### DIFF
--- a/visualize.Rmd
+++ b/visualize.Rmd
@@ -499,14 +499,16 @@ This works because every geom has a default stat; and every stat has a default g
     
     ```{r, warning = FALSE}
     demo <- tribble(
-      ~a,      ~b,
-      "bar_1", 20,
-      "bar_2", 30,
-      "bar_3", 40
+      ~cut, ~freq,
+      "Fair", 1610,
+      "Good", 4906,
+      "Very Good", 12082,
+      "Premium", 13791,
+      "Ideal", 21551,
     )
     
     ggplot(data = demo) +
-      geom_bar(mapping = aes(x = a, y = b), stat = "identity")
+      geom_bar(mapping = aes(x = cut, y = freq), stat = "identity")
     ```
     
     (Don't worry that you haven't seen `<-` or `tribble()` before. You might be

--- a/visualize.Rmd
+++ b/visualize.Rmd
@@ -499,12 +499,12 @@ This works because every geom has a default stat; and every stat has a default g
     
     ```{r, warning = FALSE}
     demo <- tribble(
-      ~cut, ~freq,
-      "Fair", 1610,
-      "Good", 4906,
-      "Very Good", 12082,
-      "Premium", 13791,
-      "Ideal", 21551,
+      ~cut,         ~freq,
+      "Fair",       1610,
+      "Good",       4906,
+      "Very Good",  12082,
+      "Premium",    13791,
+      "Ideal",      21551
     )
     
     ggplot(data = demo) +


### PR DESCRIPTION
No need to go with imaginary values when there is a nice example that is used before and after this example.