### PR TITLE
Adds the missing word "top"

### DIFF
--- a/vectors.Rmd
+++ b/vectors.Rmd
@@ -51,7 +51,7 @@ Every vector has two key properties:
 Vectors can also contain arbitrary additional metadata in the form of attributes. These attributes are used to create __augmented vectors__ which build on additional behaviour. There are four important types of augmented vector:
 
 * Factors are built on top of integer vectors.
-* Dates and date-times are built on of numeric vectors.
+* Dates and date-times are built on top of numeric vectors.
 * Data frames and tibbles are built on top of lists.
 
 This chapter will introduce you to these important vectors from simplest to most complicated. You'll start with atomic vectors, then build up to lists, and finish off with augmented vectors.


### PR DESCRIPTION
The following sentence under the section Vector Basics is missing the word "top": "Dates and date-times are built on of numeric vectors." The sentence should read: "Dates and date-times are built on top of numeric vectors."