### PR TITLE
Use visible column

### DIFF
--- a/transform.Rmd
+++ b/transform.Rmd
@@ -223,7 +223,7 @@ arrange(flights, year, month, day)
 Use `desc()` to re-order by a column in descending order:
 
 ```{r}
-arrange(flights, desc(arr_delay))
+arrange(flights, desc(dep_delay))
 ```
 
 Missing values are always sorted at the end:


### PR DESCRIPTION
for `desc()` example; the previous `arr_delay` column was invisible in the website rendering.