### PR TITLE
Changed gain to be dep_delay - arr_delay, and not vice versa.

### DIFF
--- a/transform.Rmd
+++ b/transform.Rmd
@@ -325,7 +325,7 @@ flights_sml <- select(flights,
   air_time
 )
 mutate(flights_sml,
-  gain = arr_delay - dep_delay,
+  gain = dep_delay - arr_delay,
   speed = distance / air_time * 60
 )
 ```
@@ -334,7 +334,7 @@ Note that you can refer to columns that you've just created:
 
 ```{r}
 mutate(flights_sml,
-  gain = arr_delay - dep_delay,
+  gain = dep_delay - arr_delay,
   hours = air_time / 60,
   gain_per_hour = gain / hours
 )
@@ -344,7 +344,7 @@ If you only want to keep the new variables, use `transmute()`:
 
 ```{r}
 transmute(flights,
-  gain = arr_delay - dep_delay,
+  gain = dep_delay - arr_delay,
   hours = air_time / 60,
   gain_per_hour = gain / hours
 )


### PR DESCRIPTION
At risk of being a pedant who overly engages in strictly semantic debates, I believe @DaLoneRider is correct in #594. At the outset of Section [5.5 Add new variables with `mutate()`](http://r4ds.had.co.nz/transform.html#add-new-variables-with-mutate) you have the following example:
```
library(tidyverse)
library(nycflights13)
flights_sml <- select(flights, 
  year:day, 
  ends_with("delay"), 
  distance, 
  air_time
)
mutate(flights_sml,
  gain = arr_delay - dep_delay,
  speed = distance / air_time * 60
)
``` 
which yields
```
#> # A tibble: 336,776 × 9
#>    year month   day dep_delay arr_delay distance air_time  gain speed
#>   <int> <int> <int>     <dbl>     <dbl>    <dbl>    <dbl> <dbl> <dbl>
#> 1  2013     1     1         2        11     1400      227     9   370
#> 2  2013     1     1         4        20     1416      227    16   374
```
The first flight departed 2 minutes late and arrived 11 minutes late, for a loss of 9 minutes in the air. I think of "gain" as a good thing, so losing 9 minutes in their air should be a gain of `-9`, and not `9` as in the output. This pull request fixes this.

This is unless you meant "gained delay", in which case the output is correct. 😃 
