### PR TITLE
Strings chapter: elaborate on capturing groups

### DIFF
--- a/strings.Rmd
+++ b/strings.Rmd
@@ -389,7 +389,7 @@ str_view(x, 'C[LX]+?')
 
 ### Grouping and backreferences
 
-Earlier, you learned about parentheses as a way to disambiguate complex expressions. They also define "groups" that you can refer to with _backreferences_, like `\1`, `\2` etc. For example, the following regular expression finds all fruits that have a repeated pair of letters.
+Earlier, you learned about parentheses as a way to disambiguate complex expressions. Parentheses also create a _numbered_ capturing group (number 1, 2 etc.). A capturing group stores _the part of the string_ matched by the part of the regular expression inside the parentheses. You can refer to the same text as previously matched by a capturing group with _backreferences_, like `\1`, `\2` etc. For example, the following regular expression finds all fruits that have a repeated pair of letters.
 
 ```{r}
 str_view(fruit, "(..)\\1", match = TRUE)


### PR DESCRIPTION
They idea of how _Grouping and backreferences_ work should be better elaborated.

After reading, it was not clear to me that `\1` etc. actually refer to the text matched by the first, ... capturing group. It was after reading some stuff on [this](https://www.regular-expressions.info/brackets.html) and [this](https://www.regular-expressions.info/backref.html) site that I understood this better. Therefore I made a suggestion to clarify this.