### PR TITLE
Update tidy.Rmd, typo: Spreading "forms" to "from"

### DIFF
--- a/tidy.Rmd
+++ b/tidy.Rmd
@@ -184,7 +184,7 @@ To tidy this up, we first analyse the representation in similar way to `gather()
 * The column that contains variable names, the `key` column. Here, it's 
   `type`.
 
-* The column that contains values forms multiple variables, the `value`
+* The column that contains values from multiple variables, the `value`
   column. Here it's `count`.
 
 Once we've figured that out, we can use `spread()`, as shown programmatically below, and visually in Figure \@ref(fig:tidy-spread).


### PR DESCRIPTION
Correcting typo under Spreading, defining the value variable: "contains values forms multiple variables" to "contains values from multiple variables"