### PR TITLE
Added colon in select() section

### DIFF
--- a/transform.Rmd
+++ b/transform.Rmd
@@ -273,7 +273,7 @@ There are a number of helper functions you can use within `select()`:
    This one matches any variables that contain repeated characters. You'll 
    learn more about regular expressions in [strings].
    
-*  `num_range("x", 1:3)` matches `x1`, `x2` and `x3`.
+*  `num_range("x", 1:3)`: matches `x1`, `x2` and `x3`.
    
 See `?select` for more details.
 


### PR DESCRIPTION
`num_range("x", 1:3)`:, added missing colon to match the rest of the list