### PR TITLE
change make_prediction() to model1()

### DIFF
--- a/model-basics.Rmd
+++ b/model-basics.Rmd
@@ -214,7 +214,7 @@ These are exactly the same values we got with `optim()`! Behind the scenes `lm()
     
     ```{r}
     measure_distance <- function(mod, data) {
-      diff <- data$y - make_prediction(mod, data)
+      diff <- data$y - model1(mod, data)
       mean(abs(diff))
     }
     ```


### PR DESCRIPTION
In the second exercise, you reference a function make_prediction(), which is never previously defined.  Comparing the measure_distance() function to earlier, it seems as if you mean to reference the model1() function.
This was noticed in the r4ds slack group on March 7, 2018 9:26 PM EST