### PR TITLE
Update datetimes.Rmd (trivial typo)

### DIFF
--- a/datetimes.Rmd
+++ b/datetimes.Rmd
@@ -359,7 +359,7 @@ dweeks(3)
 dyears(1)
 ```
 
-Durations always record the time span in seconds. Larger units are created by converting minutes, hours, days, weeks, and years to seconds at the standard rate (60 seconds in a minute, 60 minutes in an hour, 24 hours in day, 7 days in a week, 365 days in a year).
+Durations always record the time span in seconds. Larger units are created by converting minutes, hours, days, weeks, and years from seconds at the standard rate (60 seconds in a minute, 60 minutes in an hour, 24 hours in day, 7 days in a week, 365 days in a year).
 
 You can add and multiply durations:
 


### PR DESCRIPTION
Row 362 was : 'LARGER units are created by CONVERTING minutes, hours, days, weeks, and years TO seconds at the standard rate'.
Proposed : 'LARGER units are created by CONVERTING minutes, hours, days, weeks, and years FROM seconds at the standard rate'

I may be wrong, (and it's trivial), but keep 'bumping' on it when I read