### PR TITLE
Minor typo: dash needs to be first in character class group

### DIFF
--- a/strings.Rmd
+++ b/strings.Rmd
@@ -853,9 +853,9 @@ You can use the other arguments of `regex()` to control details of the match:
     phone <- regex("
       \\(?     # optional opening parens
       (\\d{3}) # area code
-      [-) ]?   # optional dash, closing parens, or space
+      [) -]?   # optional closing parens, space, or dash
       (\\d{3}) # another three numbers
-      [- ]?    # optional dash or space
+      [ -]?    # optional space or dash
       (\\d{3}) # three more numbers
       ", comments = TRUE)
     

--- a/strings.Rmd
+++ b/strings.Rmd
@@ -853,9 +853,9 @@ You can use the other arguments of `regex()` to control details of the match:
     phone <- regex("
       \\(?     # optional opening parens
       (\\d{3}) # area code
-      [)- ]?   # optional closing parens, dash, or space
+      [-) ]?   # optional dash, closing parens, or space
       (\\d{3}) # another three numbers
-      [ -]?    # optional space or dash
+      [- ]?    # optional dash or space
       (\\d{3}) # three more numbers
       ", comments = TRUE)
     


### PR DESCRIPTION
The phone number regex will fail if `[)- ]` ~or `[ -]`~ is used as the character class for optional dash, closing parens, or space because the `-` needs to be first (or last) in the group (or escaped).

edit: dash can be first or last inside `[]`