### PR TITLE
Fix a typo.

### DIFF
--- a/model-basics.Rmd
+++ b/model-basics.Rmd
@@ -10,7 +10,7 @@ There are two parts to a model:
 
 1.  First, you define a __family of models__ that express a precise, but 
     generic, pattern that you want to capture. For example, the pattern 
-    might be a straight line, or a quadatric curve. You will express
+    might be a straight line, or a quadratic curve. You will express
     the model family as an equation like `y = a_1 * x + a_2` or 
     `y = a_1 * x ^ a_2`. Here, `x` and `y` are known variables from your
     data, and `a_1` and `a_2` are parameters that can vary to capture 


### PR DESCRIPTION
`quadatric` to `quadratic`.