### PR TITLE
typo correction in "Durations"

### DIFF
--- a/datetimes.Rmd
+++ b/datetimes.Rmd
@@ -384,7 +384,7 @@ one_pm
 one_pm + ddays(1)
 ```
 
-Why is one day after 1pm on March 12, 2pm on March 13?! If you look carefully at the date you might also notice that the time zones have changed. Because of DST, March 12 only has 23 hours, so if add a full days worth of seconds we end up with a different time.
+Why is one day after 1pm on March 12, 2pm on March 13?! If you look carefully at the date you might also notice that the time zones have changed. Because of DST, March 12 only has 23 hours, so if we add a full days worth of seconds we end up with a different time.
 
 ### Periods
 


### PR DESCRIPTION
From: "Because of DST, March 12 only has 23 hours, so if add a full days worth of seconds we end up with a different time."
To: "Because of DST, March 12 only has 23 hours, so if we add a full days worth of seconds we end up with a different time."