### PR TITLE
small typo referencing wrong object

### DIFF
--- a/strings.Rmd
+++ b/strings.Rmd
@@ -568,7 +568,7 @@ df <- tibble(
   i = seq_along(word)
 )
 df %>% 
-  filter(str_detect(words, "x$"))
+  filter(str_detect(word, "x$"))
 ```
 
 


### PR DESCRIPTION
Line 571 should reference word, the column name in df, not words, the vector.