### PR TITLE
consistency in referring to spread functions

### DIFF
--- a/transform.Rmd
+++ b/transform.Rmd
@@ -677,8 +677,8 @@ Just using means, counts, and sum can get you a long way, but R provides many ot
     ```
 
 *   Measures of spread: `sd(x)`, `IQR(x)`, `mad(x)`. The root mean squared deviation,
-    or standard deviation or sd for short, is the standard measure of spread.
-    The interquartile range `IQR()` and median absolute deviation `mad(x)`
+    or standard deviation `sd(x)`, is the standard measure of spread.
+    The interquartile range `IQR(x)` and median absolute deviation `mad(x)`
     are robust equivalents that may be more useful if you have outliers.
     
     ```{r}


### PR DESCRIPTION
imho the referring to function names in this section is a bit sloppy. `sd` is merged in the text without function quotes. `IQR()` is without `x`, while `mad(x)` is. Since other functions in this sections are referred to as `funname(x)`, I opt for that in this section as well.