### PR TITLE
Could you enable HTTPS?

### DIFF
--- a/index.rmd
+++ b/index.rmd
@@ -3,7 +3,7 @@ knit: "bookdown::render_book"
 title: "R for Data Science"
 author: ["Garrett Grolemund", "Hadley Wickham"]
 description: "This book will teach you how to do data science with R: You'll learn how to get your data into R, get it into the most useful structure, transform it, visualise it and model it. In this book, you will find a practicum of skills for data science. Just as a chemist learns how to clean test tubes and stock a lab, you'll learn how to clean data and draw plots---and many other things besides. These are the skills that allow data science to happen, and here you will find the best practices for doing each of these things with R. You'll learn how to use the grammar of graphics, literate programming, and reproducible research to save time. You'll also learn how to manage cognitive resources to facilitate discoveries when wrangling, visualising, and exploring data."
-url: 'http\://r4ds.had.co.nz/'
+url: 'https\://r4ds.had.co.nz/'
 github-repo: hadley/r4ds
 twitter-handle: hadley
 cover-image: cover.png


### PR DESCRIPTION
so that the bookdown.org homepage is completely secure. Currently this is the only book in the list which has not enabled HTTPS yet.

Thanks!