### PR TITLE
correct indentation of a list item in vectors.Rmd

### DIFF
--- a/vectors.Rmd
+++ b/vectors.Rmd
@@ -82,10 +82,10 @@ typeof(1L)
 
 The distinction between integers and doubles is not usually important, but there are two important differences that you should be aware of:
 
-1.   Doubles are approximations. Doubles represent floating point numbers that 
-     can not always be precisely represented with a fixed amount of memory. 
-     This means that you should consider all doubles to be approximations. 
-     For example, what is square of the square root of two?
+1.  Doubles are approximations. Doubles represent floating point numbers that 
+    can not always be precisely represented with a fixed amount of memory. 
+    This means that you should consider all doubles to be approximations. 
+    For example, what is square of the square root of two?
 
     ```{r}
     x <- sqrt(2) ^ 2


### PR DESCRIPTION
The beginning "Double" is five space away from the left margin, while the R code chunk is only four thus not recognized as block element by Pandoc.