### PR TITLE
Fix typo in model-basics.Rmd, line 95

### DIFF
--- a/model-basics.Rmd
+++ b/model-basics.Rmd
@@ -92,7 +92,7 @@ ggplot(dist1, aes(x1, y)) +
   geom_linerange(aes(ymin = y, ymax = pred), colour = "#3366FF") 
 ```
 
-This distance is just the difference between the y value given by the model (the __prediction__), and the actual y value in the data (the __response__).
+This distance is just the difference between the value given by the model (the __prediction__), and the actual y value in the data (the __response__).
 
 To compute this distance, we first turn our model family into an R function. This takes the model parameters and the data as inputs, and gives values predicted by the model as output:
 


### PR DESCRIPTION
Removing the  __y__  in:

This distance is just the difference between the __y__ value given by the model (the __prediction__), and the actual y value in the data (the __response__).