### PR TITLE
Markdown format fix: Quote attribution moved into blockquote

### DIFF
--- a/model-building.Rmd
+++ b/model-building.Rmd
@@ -16,8 +16,8 @@ It's a challenge to know when to stop. You need to figure out when your model is
 > in life, I heard "A poor seamstress makes many mistakes. A good seamstress 
 > works hard to correct those mistakes. A great seamstress isn't afraid to 
 > throw out the garment and start over."
-
--- Broseidon241, <https://www.reddit.com/r/datascience/comments/4irajq>
+> 
+> -- Broseidon241, <https://www.reddit.com/r/datascience/comments/4irajq>
 
 ### Prerequisites
 


### PR DESCRIPTION
I assume that the attribution of the quote to the person be in the same blockquote as the quote itself.