### PR TITLE
add missing word

### DIFF
--- a/index.rmd
+++ b/index.rmd
@@ -29,7 +29,7 @@ contributors <- contributors %>%
     desc = ifelse(is.na(name), link, glue::glue("{name} ({link})"))
   )
 
-cat("A big thanks goes to everyone has contributed!\n")
+cat("A big thanks goes to everyone who has contributed!\n")
 cat(paste0(contributors$desc, collapse = ", "))
 ```
 


### PR DESCRIPTION
Fix typo: missing word in the acknowledgements on the Welcome page.