### PR TITLE
Removed now-redundant sentence and code segment.

### DIFF
--- a/factors.Rmd
+++ b/factors.Rmd
@@ -10,6 +10,10 @@ Historically, factors were much easier to work with than characters. As a result
 
 To work with factors, we'll use the __forcats__ package, which provides tools for dealing with **cat**egorical variables (and it's an anagram of factors!). It provides a wide range of helpers for working with factors.
 
+```{r setup, message = FALSE}
+library(tidyverse)
+```
+
 ### Learning more
 
 If you want to learn more about factors, I recommend reading Amelia McNamara and Nicholas Horton’s paper, [_Wrangling categorical data in R_](https://peerj.com/preprints/3163/). This paper lays out some of the history discussed in [_stringsAsFactors: An unauthorized biography_](http://simplystatistics.org/2015/07/24/stringsasfactors-an-unauthorized-biography/) and [_stringsAsFactors = \<sigh\>_](http://notstatschat.tumblr.com/post/124987394001/stringsasfactors-sigh), and compares the tidy approaches to categorical data outlined in this book with base R methods. A early version of the paper help motivate and scope the forcats package; thanks Amelia & Nick!


### PR DESCRIPTION
Removed:

> forcats is not part of the core tidyverse, so we need to load it explicitly.
> 
> library(tidyverse)
> library(forcats)

forcats is now a part of the core tidyverse and no longer needs to be loaded explicitly.

>library(tidyverse)  