### PR TITLE
fixed a typo

### DIFF
--- a/functions.Rmd
+++ b/functions.Rmd
@@ -629,7 +629,7 @@ Here `...` lets me forward on any arguments that I don't want to deal with to `s
 
 ```{r}
 x <- c(1, 2)
-sum(x, na.mr = TRUE)
+sum(x, na.rm = TRUE)
 ```
 
 If you just want to capture the values of the `...`, use `list(...)`.


### PR DESCRIPTION
At line number 632, there was typo "na.mr" instead of na.rm. 
Changed "sum(x, na.mr = TRUE)" to "sum(x, na.rm = TRUE)"