### PR TITLE
Remove use of mu in exercises

### DIFF
--- a/iteration.Rmd
+++ b/iteration.Rmd
@@ -102,7 +102,7 @@ That's all there is to the for loop! Now is a good time to practice creating som
     1. Compute the mean of every column in `mtcars`.
     1. Determine the type of each column in `nycflights13::flights`.
     1. Compute the number of unique values in each column of `iris`.
-    1. Generate 10 random normals for each of $\mu = -10$, $0$, $10$, and $100$.
+    1. Generate 10 random normals from distributions with means of -10, 0, 10, and 100.
     
     Think about the output, sequence, and body __before__ you start writing
     the loop.
@@ -623,7 +623,7 @@ I focus on purrr functions here because they have more consistent names and argu
     1. Compute the mean of every column in `mtcars`.
     1. Determine the type of each column in `nycflights13::flights`.
     1. Compute the number of unique values in each column of `iris`.
-    1. Generate 10 random normals for each of $\mu = -10$, $0$, $10$, and $100$.
+    1. Generate 10 random normals from distributions with means of -10, 0, 10, and 100.
 
 1.  How can you create a single vector that for each column in a data frame
     indicates whether or not it's a factor?


### PR DESCRIPTION
Two exercises use $\mu$ to mean the mean parameter of a normal distribution. However, nowhere in the book is it defined as such. For clarity replace $\mu$ with "mean".