### PR TITLE
Rename "Practice" sections to "Exercises"

### DIFF
--- a/functions.Rmd
+++ b/functions.Rmd
@@ -129,7 +129,7 @@ rescale01(x)
 
 This is an important part of the "do not repeat yourself" (or DRY) principle. The more repetition you have in your code, the more places you need to remember to update when things change (and they always do!), and the more likely you are to create bugs over time.
 
-### Practice
+### Exercises
 
 1.  Why is `TRUE` not a parameter to `rescale01()`? What would happen if
     `x` contained a single missing value, and `na.rm` was `FALSE`?

--- a/workflow-basics.Rmd
+++ b/workflow-basics.Rmd
@@ -128,7 +128,7 @@ knitr::include_graphics("screenshots/rstudio-env.png")
 
 Here you can see all of the objects that you've created.
 
-## Practice
+## Exercises
 
 1.  Why does this code not work?
 

--- a/workflow-scripts.Rmd
+++ b/workflow-scripts.Rmd
@@ -50,7 +50,7 @@ RStudio will also let you know about potential problems:
 knitr::include_graphics("screenshots/rstudio-diagnostic-warn.png")
 ```
 
-## Practice
+## Exercises
 
 1.  Go to the RStudio Tips twitter account, <https://twitter.com/rstudiotips>
     and find one tip that looks interesting. Practice using it!


### PR DESCRIPTION
Some sections with exercises are titled "Practice", while most are titled "Exercises".
This commit renames all of these to "Exercises".