### PR TITLE
Assuring minimal version of Rstudio

### DIFF
--- a/intro.Rmd
+++ b/intro.Rmd
@@ -107,7 +107,7 @@ A new major version of R comes out once a year, and there are 2-3 minor releases
 
 ### RStudio
 
-RStudio is an integrated development environment, or IDE, for R programming. Download and install it from <http://www.rstudio.com/download>. RStudio is updated a couple of times a year. When a new version is available, RStudio will let you know. It's a good idea to upgrade regularly so you can take advantage of the latest and greatest features. For this book, make sure you have RStudio 1.0.0.
+RStudio is an integrated development environment, or IDE, for R programming. Download and install it from <http://www.rstudio.com/download>. RStudio is updated a couple of times a year. When a new version is available, RStudio will let you know. It's a good idea to upgrade regularly so you can take advantage of the latest and greatest features. For this book, make sure you have at least RStudio 1.0.0.
 
 When you start RStudio, you'll see two key regions in the interface:
 


### PR DESCRIPTION
I don't think it is meant that the user should have version 1.0.0 of Rstudio, but have a version that is at least 1.0.0. The link of course refers to the latest version. A savvy reader might think he / she should start searching for 1.0.0 with the current text.