### PR TITLE
Revert typo

### DIFF
--- a/workflow-basics.Rmd
+++ b/workflow-basics.Rmd
@@ -146,7 +146,7 @@ Here you can see all of the objects that you've created.
     ```{r, eval = FALSE}
     library(tidyverse)
 
-    ggplot(data = mpg) + 
+    ggplot(dota = mpg) + 
       geom_point(mapping = aes(x = displ, y = hwy))
     
     fliter(mpg, cyl = 8)


### PR DESCRIPTION
Issue #681 fixed a typo in the code for an exercise, `dota` to `data`. However, the exercise should have typos, since the purpose of the exercise is to fix typos.

> Tweak each of the following R commands so that they run correctly:

This PR restores the typo so the code correctly works incorrectly.