### PR TITLE
Update import.Rmd to match current readr behavior (first 1000 NAs)

### DIFF
--- a/import.Rmd
+++ b/import.Rmd
@@ -455,7 +455,7 @@ These defaults don't always work for larger files. There are two basic problems:
     a column of doubles that only contains integers in the first 1000 rows. 
 
 1.  The column might contain a lot of missing values. If the first 1000
-    rows contain only `NA`s, readr will guess that it's a character 
+    rows contain only `NA`s, readr will guess that it's a logical 
     vector, whereas you probably want to parse it as something more
     specific.
 


### PR DESCRIPTION
I think this is the current readr behavior when the first 1000 rows contain only NAs.
Kind regards