### PR TITLE
Update strings.Rmd 13.5 exercise questions

### DIFF
--- a/strings.Rmd
+++ b/strings.Rmd
@@ -412,9 +412,9 @@ str_view(fruit, "(..)\\1", match = TRUE)
 
 1.  Describe, in words, what these expressions will match:
 
-    1. `(.)\1\1`
+    1. `"(.)\\1\\1"`
     1. `"(.)(.)\\2\\1"`
-    1. `(..)\1`
+    1. `"(..)\\1"`
     1. `"(.).\\1.\\1"`
     1. `"(.)(.)(.).*\\3\\2\\1"`
 


### PR DESCRIPTION
It looks that the double quotes and a backslash are missing in the 14.3.5.1 Excercise questions.