### PR TITLE
Replace `[[` with `[` on vectors.

### DIFF
--- a/iteration.Rmd
+++ b/iteration.Rmd
@@ -53,7 +53,7 @@ But that breaks our rule of thumb: never copy and paste more than twice. Instead
 ```{r}
 output <- vector("double", ncol(df))  # 1. output
 for (i in seq_along(df)) {            # 2. sequence
-  output[[i]] <- median(df[[i]])      # 3. body
+  output[i] <- median(df[[i]])      # 3. body
 }
 output
 ```
@@ -88,10 +88,10 @@ Every for loop has three components:
     it's easy to create them accidentally. If you use `1:length(x)` instead
     of `seq_along(x)`, you're likely to get a confusing error message.
     
-1.  The __body__: `output[[i]] <- median(df[[i]])`. This is the code that does
+1.  The __body__: `output[i] <- median(df[[i]])`. This is the code that does
     the work. It's run repeatedly, each time with a different value for `i`.
-    The first iteration will run `output[[1]] <- median(df[[1]])`, 
-    the second will run `output[[2]] <- median(df[[2]])`, and so on.
+    The first iteration will run `output[1] <- median(df[[1]])`, 
+    the second will run `output[2] <- median(df[[2]])`, and so on.
 
 That's all there is to the for loop! Now is a good time to practice creating some basic (and not so basic) for loops using the exercises below. Then we'll move on some variations of the for loop that help you solve other problems that will crop up in practice. 
 
@@ -386,7 +386,7 @@ Imagine you want to compute the mean of every column. You could do that with a f
 ```{r}
 output <- vector("double", length(df))
 for (i in seq_along(df)) {
-  output[[i]] <- mean(df[[i]])
+  output[i] <- mean(df[[i]])
 }
 output
 ```


### PR DESCRIPTION
Not sure if this was done on purpose, but I found several `[[` operators used on atomic vectors.