### PR TITLE
Update Chp 8 exercise on quote arg of read_csv(). 

### DIFF
--- a/import.Rmd
+++ b/import.Rmd
@@ -120,9 +120,8 @@ If you've used R before, you might wonder why we're not using `read.csv()`. Ther
    
 1.  Sometimes strings in a CSV file contain commas. To prevent them from
     causing problems they need to be surrounded by a quoting character, like
-    `"` or `'`. By convention, `read_csv()` assumes that the quoting
-    character will be `"`, and if you want to change it you'll need to
-    use `read_delim()` instead. What arguments do you need to specify
+    `"` or `'`. By default, `read_csv()` assumes that the quoting
+    character will be `"`. What argument to `read_csv()` do you need to specify
     to read the following text into a data frame?
     
     ```{r, eval = FALSE}


### PR DESCRIPTION
The `read_csv()` function has had the argument `quote` since readr [1.1.0](https://github.com/tidyverse/readr/blob/master/NEWS.md#readr-110) released in March 2017 (see PR https://github.com/tidyverse/readr/pull/631).

Closes Issue #696 from @jrnold.

And just in case: "I assign the copyright of this contribution to Hadley Wickham"