### PR TITLE
Drop na.rm=TRUE when data is already purged of NAs

### DIFF
--- a/transform.Rmd
+++ b/transform.Rmd
@@ -592,7 +592,7 @@ The story is actually a little more nuanced. We can get more insight if we draw 
 delays <- not_cancelled %>% 
   group_by(tailnum) %>% 
   summarise(
-    delay = mean(arr_delay, na.rm = TRUE),
+    delay = mean(arr_delay),
     n = n()
   )
 


### PR DESCRIPTION
In transform.Rmd (Chapter 5, Data Transformation), under Counts (5.6.3), we removed na.rm = TRUE when computing mean because all NAs for arr_delay were already removed when creating not_cancelled dataset.