### PR TITLE
Small typos in tidy chapter

### DIFF
--- a/tidy.Rmd
+++ b/tidy.Rmd
@@ -220,8 +220,8 @@ As you might have guessed from their names, `pivot_wider()` and `pivot_longer()`
     
     (Hint: look at the variable types and think about column _names_.)
     
-    `pivot_longer()` has a `names_ptype` argument, e.g. 
-    `names_ptype = list(year = double())`. What does it do?
+    `pivot_longer()` has a `names_ptypes` argument, e.g. 
+    `names_ptypes = list(year = double())`. What does it do?
 
 1.  Why does this code fail?
 

--- a/tidy.Rmd
+++ b/tidy.Rmd
@@ -482,7 +482,7 @@ You might be able to parse this out by yourself with a little thought and some e
     *   `ep` stands for cases of extrapulmonary TB
     *   `sn` stands for cases of pulmonary TB that could not be diagnosed by 
         a pulmonary smear (smear negative)
-    *   `sp` stands for cases of pulmonary TB that could be diagnosed be 
+    *   `sp` stands for cases of pulmonary TB that could be diagnosed by 
         a pulmonary smear (smear positive)
 
 3.  The sixth letter gives the sex of TB patients. The dataset groups 

--- a/tidy.Rmd
+++ b/tidy.Rmd
@@ -450,7 +450,7 @@ The best place to start is almost always to gather together the columns that are
   in the variable names (e.g. `new_sp_m014`, `new_ep_m014`, `new_ep_f014`) 
   these are likely to be values, not variables.
 
-So we need to gather together all the columns from `new_sp_m014` to `newrel_f65`. We don't know what those values represent yet, so we'll give them the generic name `"key"`. We know the cells represent the count of cases, so we'll use the variable `cases`. There are a lot of missing values in the current representation, so for now we'll use `na.rm` just so we can focus on the values that are present.
+So we need to gather together all the columns from `new_sp_m014` to `newrel_f65`. We don't know what those values represent yet, so we'll give them the generic name `"key"`. We know the cells represent the count of cases, so we'll use the variable `cases`. There are a lot of missing values in the current representation, so for now we'll use `values_drop_na` just so we can focus on the values that are present.
 
 ```{r}
 who1 <- who %>% 


### PR DESCRIPTION
This PR fixes minor typos in the tidy chapter:
- `names_ptype` should be `names_ptypes`
- `na.rm` should be `values_drop_na`
- "be diagnosed be" should be "be diagnosed by"