### PR TITLE
Provide arguments to nest() and unnest() to get rid of tidyr warnings

### DIFF
--- a/model-many.Rmd
+++ b/model-many.Rmd
@@ -351,7 +351,7 @@ You can also use it on an ungrouped data frame, specifying which columns you wan
 
 ```{r}
 gapminder %>% 
-  nest(year:gdpPercap)
+  nest(data = c(year:gdpPercap))
 ```
 
 ### From vectorised functions
@@ -374,7 +374,7 @@ df %>%
 ```{r}
 df %>% 
   mutate(x2 = stringr::str_split(x1, ",")) %>% 
-  unnest()
+  unnest(x2)
 ```
 
 (If you find yourself using this pattern a lot, make sure to check out `tidyr::separate_rows()` which is a wrapper around this common pattern).
@@ -420,7 +420,7 @@ probs <- c(0.01, 0.25, 0.5, 0.75, 0.99)
 mtcars %>% 
   group_by(cyl) %>% 
   summarise(p = list(probs), q = list(quantile(mpg, probs))) %>% 
-  unnest()
+  unnest(c(p, q))
 ```
 
 ### From a named list
@@ -464,7 +464,7 @@ df %>%
     mtcars %>% 
       group_by(cyl) %>% 
       summarise(q = list(quantile(mpg))) %>% 
-      unnest()
+      unnest(q)
     ```
 
 1.  What does this code do? Why might might it be useful?
@@ -540,7 +540,7 @@ df1 <- tribble(
    2, "c",           3
 )
 df1
-df1 %>% unnest(y, z)
+df1 %>% unnest(c(y, z))
 
 # Doesn't work because y and z have different number of elements
 df2 <- tribble(
@@ -549,7 +549,7 @@ df2 <- tribble(
    2, c("b", "c"),   3
 )
 df2
-df2 %>% unnest(y, z)
+df2 %>% unnest(c(y, z))
 ```
 
 The same principle applies when unnesting list-columns of data frames. You can unnest multiple list-cols as long as all the data frames in each row have the same number of rows.


### PR DESCRIPTION
This PR deals with *most* warnings raised by tidyr due to the changes in the syntax of `nest()`/`unnest()` introduced in [version 1.1.0](https://github.com/tidyverse/tidyr/blob/master/NEWS.md#tidyr-100).

For example:
```r
gapminder %>% 
  nest(year:gdpPercap)
#> Warning: All elements of `...` must be named.
#> Did you want `data = c(year, lifeExp, pop, gdpPercap)`?
#> # A tibble: 142 x 3
#>   country     continent           data
#>   <fct>       <fct>     <list<df[,4]>>
#> 1 Afghanistan Asia            [12 × 4]
#> 2 Albania     Europe          [12 × 4]
#> 3 Algeria     Africa          [12 × 4]
#> 4 Angola      Africa          [12 × 4]
#> 5 Argentina   Americas        [12 × 4]
#> 6 Australia   Oceania         [12 × 4]
#> # … with 136 more rows
```

Or:

```r
df %>% 
  mutate(x2 = stringr::str_split(x1, ",")) %>% 
  unnest()
#> Warning: `cols` is now required.
#> Please use `cols = c(x2)`
#> # A tibble: 7 x 2
#>   x1      x2   
#>   <chr>   <chr>
#> 1 a,b,c   a    
#> 2 a,b,c   b    
#> 3 a,b,c   c    
#> 4 d,e,f,g d    
#> 5 d,e,f,g e    
#> 6 d,e,f,g f    
#> # … with 1 more row
```

There are two other cases where changes in the tidyr API affect the exercises or explanations in the chapter. Since these are more complex, I will flag them in separate issues. **Edit:** See #826 and #827 