### PR TITLE
Update ggplot cheat sheet link

### DIFF
--- a/visualize.Rmd
+++ b/visualize.Rmd
@@ -346,7 +346,7 @@ ggplot(data = mpg, mapping = aes(x = displ, y = hwy, color = drv)) +
 
 Notice that this plot contains two geoms in the same graph! If this makes you excited, buckle up. We will learn how to place multiple geoms in the same plot very soon.
 
-ggplot2 provides over 40 geoms, and extension packages provide even more (see <https://www.ggplot2-exts.org> for a sampling). The best way to get a comprehensive overview is the ggplot2 cheatsheet, which you can find at <http://rstudio.com/cheatsheets>. To learn more about any single geom, use help: `?geom_smooth`.
+ggplot2 provides over 40 geoms, and extension packages provide even more (see <https://www.ggplot2-exts.org> for a sampling). The best way to get a comprehensive overview is the Data Visualization Cheat Sheet, which you can find at <https://rstudio.com/resources/cheatsheets/>. To learn more about any single geom, use help: `?geom_smooth`.
 
 Many geoms, like `geom_smooth()`, use a single geometric object to display multiple rows of data. For these geoms, you can set the `group` aesthetic to a categorical variable to draw multiple objects. ggplot2 will draw a separate object for each unique value of the grouping variable. In practice, ggplot2 will automatically group the data for these geoms whenever you map an aesthetic to a discrete variable (as in the `linetype` example). It is convenient to rely on this feature because the group aesthetic by itself does not add a legend or distinguishing features to the geoms.
 


### PR DESCRIPTION
RStudio changed the location of its cheat sheets to https://rstudio.com/resources/cheatsheets/. They also updated the section heading for the ggplot cheat sheet to "Data Visualization Cheat Sheet".