### PR TITLE
Correcting uses of "data frame" to be a "tibble"

### DIFF
--- a/visualize.Rmd
+++ b/visualize.Rmd
@@ -34,9 +34,9 @@ If we need to be explicit about where a function (or dataset) comes from, we'll 
 
 Let's use our first graph to answer a question: Do cars with big engines use more fuel than cars with small engines? You probably already have an answer, but try to make your answer precise. What does the relationship between engine size and fuel efficiency look like? Is it positive? Negative? Linear? Nonlinear?
 
-### The `mpg` data frame
+### The `mpg` tibble
 
-You can test your answer with the `mpg` __data frame__ found in ggplot2 (aka  `ggplot2::mpg`). A data frame is a rectangular collection of variables (in the columns) and observations (in the rows). `mpg` contains observations collected by the US Environmental Protection Agency on 38 models of car. 
+You can test your answer with the `mpg` __tibble__ found in ggplot2 (aka  `ggplot2::mpg`). A tibble is a rectangular collection of variables (in the columns) and observations (in the rows). `mpg` contains observations collected by the US Environmental Protection Agency on 38 models of car. 
 
 ```{r}
 mpg


### PR DESCRIPTION
In chapter 3, section 3.2.1, **data frame** is used a few times to describe the **mpg** "_tibble_". This fixes that, addressing issue #833 .