### PR TITLE
obsolete link for RStudio cheatsheets

### DIFF
--- a/rmarkdown.Rmd
+++ b/rmarkdown.Rmd
@@ -24,7 +24,7 @@ R Markdown integrates a number of R packages and external tools. This means that
 *   R Markdown Reference Guide: _Help > Cheatsheets > R Markdown Reference 
     Guide_.
 
-Both cheatsheets are also available at <http://rstudio.com/cheatsheets>.
+Both cheatsheets are also available at <https://rstudio.com/resources/cheatsheets/>.
 
 ### Prerequisites
 


### PR DESCRIPTION
The current link is : https://rstudio.com/resources/cheatsheets/