### PR TITLE
Update stat_summary args for ggplot2 3.3.0

### DIFF
--- a/visualize.Rmd
+++ b/visualize.Rmd
@@ -537,9 +537,9 @@ This works because every geom has a default stat; and every stat has a default g
     ggplot(data = diamonds) + 
       stat_summary(
         mapping = aes(x = cut, y = depth),
-        fun.ymin = min,
-        fun.ymax = max,
-        fun.y = median
+        fun.min = min,
+        fun.max = max,
+        fun = median
       )
     ```
     


### PR DESCRIPTION
Although the plot still works, despite using the deprecated arguments `fun.ymin`, `fun.y`, `fun.ymax`, it makes the following exercise (1.) hard for learners to complete, since passing these arguments through `geom_pointrange()` gives the error:
  ```r
Ignoring unknown parameters: fun.ymin, fun.ymax, fun.y 
```
