### PR TITLE
Update tidy.Rmd

### DIFF
--- a/tidy.Rmd
+++ b/tidy.Rmd
@@ -503,7 +503,7 @@ We need to make a minor fix to the format of the column names: unfortunately the
 
 ```{r}
 who2 <- who1 %>% 
-  mutate(names_from = stringr::str_replace(key, "newrel", "new_rel"))
+  mutate(key = stringr::str_replace(key, "newrel", "new_rel"))
 who2
 ```
 
@@ -560,7 +560,7 @@ who %>%
     missing values? What's the difference between an `NA` and zero? 
 
 1.  What happens if you neglect the `mutate()` step?
-    (`mutate(names_from = stringr::str_replace(key, "newrel", "new_rel"))`)
+    (`mutate(key = stringr::str_replace(key, "newrel", "new_rel"))`)
 
 1.  I claimed that `iso2` and `iso3` were redundant with `country`. 
     Confirm this claim.


### PR DESCRIPTION
The new variable `names_from` created from the original code 
```
who2 <- who1 %>% 
  mutate(names_from = stringr::str_replace(key, "newrel", "new_rel"))
```
caused a warning in the next step while assigning `who2 `to `who3` with the `dplyr::select()`.
