### PR TITLE
Use after_stat instead of the old dotted syntax.

### DIFF
--- a/visualize.Rmd
+++ b/visualize.Rmd
@@ -565,9 +565,9 @@ ggplot2 provides over 20 stats for you to use. Each stat is a function, so you c
     
     ```{r, eval = FALSE}
     ggplot(data = diamonds) + 
-      geom_bar(mapping = aes(x = cut, y = ..prop..))
+      geom_bar(mapping = aes(x = cut, y = after_stat(prop)))
     ggplot(data = diamonds) + 
-      geom_bar(mapping = aes(x = cut, fill = color, y = ..prop..))
+      geom_bar(mapping = aes(x = cut, fill = color, y = after_stat(prop)))
     ```
   
 


### PR DESCRIPTION
The `..` syntax in 3.7 Exercises to refer to computed variable `prop` should be updated to use the best practice of `after_stat` instead. Reduces confusion and better aligns with the documentation.