### PR TITLE
Model-many.Rmd: map2 w/ add_residuals adds a tibble

### DIFF
--- a/model-many.Rmd
+++ b/model-many.Rmd
@@ -166,6 +166,9 @@ by_country <- by_country %>%
 by_country
 ```
 
+It is important to note that calling `add_residuals()` through `map2()` doesn't simply add a new column `resids` containing
+the residuals as doubles, as we have already done many times. Instead, a new column that contains a `tibble` is added! It is the same tibble as `data`, just with the residuals added in a new column by `add_residuals()`.
+
 But how you can plot a list of data frames? Instead of struggling to answer that question, let's turn the list of data frames back into a regular data frame. Previously we used `nest()` to turn a regular data frame into an nested data frame, and now we do the opposite with `unnest()`:
 
 ```{r}


### PR DESCRIPTION
Clarify and point out that we now don't have a double column but a tibble column added by the `add_residuals` call; this is a big difference to what we did before and in my opinion worth mentioning as it is easily skipped.