### PR TITLE
Update tidy.Rmd - Line 506 Typo

### DIFF
--- a/tidy.Rmd
+++ b/tidy.Rmd
@@ -503,7 +503,7 @@ We need to make a minor fix to the format of the column names: unfortunately the
 
 ```{r}
 who2 <- who1 %>% 
-  mutate(names_from = stringr::str_replace(key, "newrel", "new_rel"))
+  mutate(key = stringr::str_replace(key, "newrel", "new_rel"))
 who2
 ```
 


### PR DESCRIPTION
Line 506: 
When fixing the string format in the `key` column using the `str_replace` function, I think the column name was mistakenly stated as "names_from", where it should actually be "key", which is the original column name.