### PR TITLE
one_of() is retired

### DIFF
--- a/transform.Rmd
+++ b/transform.Rmd
@@ -297,7 +297,7 @@ select(flights, time_hour, air_time, everything())
 1.  What happens if you include the name of a variable multiple times in
     a `select()` call?
   
-1.  What does the `one_of()` function do? Why might it be helpful in conjunction
+1.  What does the `any_of()` function do? Why might it be helpful in conjunction
     with this vector?
     
     ```{r}


### PR DESCRIPTION
Further to {tidyselect} documentation "one_of() is retired in favour of the more precise any_of() and all_of() selectors." this exercise (5.4.1) should be updated to be in-line with current functionality.