### PR TITLE
remove indication of warning

### DIFF
--- a/datetimes.Rmd
+++ b/datetimes.Rmd
@@ -455,7 +455,7 @@ flights_dt %>%
 
 It's obvious what `dyears(1) / ddays(365)` should return: one, because durations are always represented by a number of seconds, and a duration of a year is defined as 365 days worth of seconds.
 
-What should `years(1) / days(1)` return? Well, if the year was 2015 it should return 365, but if it was 2016, it should return 366! There's not quite enough information for lubridate to give a single clear answer. What it does instead is give an estimate, with a warning:
+What should `years(1) / days(1)` return? Well, if the year was 2015 it should return 365, but if it was 2016, it should return 366! There's not quite enough information for lubridate to give a single clear answer. What it does instead is give an estimate:
 
 ```{r}
 years(1) / days(1)


### PR DESCRIPTION
Warning does not appear: lubridate version 1.7.9; R version 4.0.2 (2020-06-22) -- "Taking Off Again"

``` r
library(lubridate)
#> 
#> Attaching package: 'lubridate'
#> The following objects are masked from 'package:base':
#> 
#>     date, intersect, setdiff, union
years(1) / days(1)
#> [1] 365.25
```

<sup>Created on 2020-10-07 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>