### PR TITLE
A spelling fix

### DIFF
--- a/rmarkdown.Rmd
+++ b/rmarkdown.Rmd
@@ -189,7 +189,7 @@ The most important set of options controls if your code block is executed and wh
     and want to deliberately include an error. The default, `error = FALSE` causes 
     knitting to fail if there is a single error in the document.
     
-The following table summarises which types of output each option supressess:
+The following table summarises which types of output each option suppresses:
 
 Option             | Run code | Show code | Output | Plots | Messages | Warnings 
 -------------------|----------|-----------|--------|-------|----------|---------


### PR DESCRIPTION
'supressess' changed to 'suppresses'