### PR TITLE
dplyr::count() does have a .drop option

### DIFF
--- a/factors.Rmd
+++ b/factors.Rmd
@@ -125,7 +125,13 @@ ggplot(gss_cat, aes(race)) +
   scale_x_discrete(drop = FALSE)
 ```
 
-These levels represent valid values that simply did not occur in this dataset. Unfortunately, dplyr doesn't yet have a `drop` option, but it will in the future.
+These levels represent valid values that simply did not occur in this dataset. In dplyr::count() set the `.drop` option to `FALSE`, to show these.
+
+```{r}
+gss_cat %>% 
+  count(race, 
+        .drop = FALSE)
+```
 
 When working with factors, the two most common operations are changing the order of the levels, and changing the values of the levels. Those operations are described in the sections below.
 


### PR DESCRIPTION
We can include levels with no observations in dplyr::count() now with the .drop = FALSE argument setting. I changed the wording and added an example. Please feel free to amend text wording, and remove example, if you wish.