### PR TITLE
Switch from stat() to after_stat() in chap 3.

### DIFF
--- a/visualize.Rmd
+++ b/visualize.Rmd
@@ -522,7 +522,7 @@ This works because every geom has a default stat; and every stat has a default g
     
     ```{r}
     ggplot(data = diamonds) + 
-      geom_bar(mapping = aes(x = cut, y = stat(prop), group = 1))
+      geom_bar(mapping = aes(x = cut, y = after_stat(prop), group = 1))
     ```
 
     To find the variables computed by the stat, look for the help section


### PR DESCRIPTION
The docs in of aes_eval in [most recent](https://ggplot2.tidyverse.org/reference/aes_eval.html?q=after%20_%20stat#arguments) ggplot2 3.3.2 say that after_stat() and after_scale() has replaced stat().