### PR TITLE
Removed reference to deprecated .drop argument

### DIFF
--- a/model-many.Rmd
+++ b/model-many.Rmd
@@ -209,16 +209,8 @@ We can use `mutate()` and `unnest()` to create a data frame with a row for each 
 ```{r}
 by_country %>% 
   mutate(glance = map(model, broom::glance)) %>% 
+  select(-data, -model, -resids) %>% # removing the unnecessary list columns
   unnest(glance)
-```
-
-This isn't quite the output we want, because it still includes all the list columns. This is default behaviour when `unnest()` works on single row data frames. To suppress these columns we use `.drop = TRUE`:
-
-```{r}
-glance <- by_country %>% 
-  mutate(glance = map(model, broom::glance)) %>% 
-  unnest(glance, .drop = TRUE)
-glance
 ```
 
 (Pay attention to the variables that aren't printed: there's a lot of useful stuff there.)


### PR DESCRIPTION
According to the output and documentation, `.drop` was deprecated as an argument.  I'd propose just removing this chunk and adding a comment in the original `unnest(glance)` pipeline.

Here's what is currently showing up in the R4DS book https://r4ds.had.co.nz/many-models.html#model-quality

![image](https://user-images.githubusercontent.com/6612411/98446546-050f2900-20d3-11eb-8b6b-dfddbabfa236.png)

Thanks for all the awesome work on this!  I found this section really helpful to read through this morning.