### PR TITLE
Potential typo?

### DIFF
--- a/vectors.Rmd
+++ b/vectors.Rmd
@@ -636,7 +636,7 @@ typeof(y)
 attributes(y)
 ```
 
-POSIXlts are rare inside the tidyverse. They do crop up in base R, because they are needed to extract specific components of a date, like the year or month. Since lubridate provides helpers for you to do this instead, you don't need them. POSIXct's are always easier to work with, so if you find you have a POSIXlt, you should always convert it to a regular data time `lubridate::as_date_time()`.
+POSIXlts are rare inside the tidyverse. They do crop up in base R, because they are needed to extract specific components of a date, like the year or month. Since lubridate provides helpers for you to do this instead, you don't need them. POSIXct's are always easier to work with, so if you find you have a POSIXlt, you should always convert it to a regular date time `lubridate::as_date_time()`.
 
 ### Tibbles
 


### PR DESCRIPTION
I don't know if it was meant to be this way, because it's actually not weird to say `data time` but assuming it was meant to be `date time` I amended:

regular data time `lubridate::as_date_time()` -> regular date time `lubridate::as_date_time()`