### PR TITLE
Update model-many.Rmd

### DIFF
--- a/model-many.Rmd
+++ b/model-many.Rmd
@@ -217,7 +217,8 @@ This isn't quite the output we want, because it still includes all the list colu
 ```{r}
 glance <- by_country %>% 
   mutate(glance = map(model, broom::glance)) %>% 
-  unnest(glance, .drop = TRUE)
+  select(-data,-model,-resids) %>%
+  unnest(glance)
 glance
 ```
 


### PR DESCRIPTION
line 220-221, the .drop is deprecated, using select to remove the three list-columns: data, model, and resids instead.