### PR TITLE
Fix fct_lump example

### DIFF
--- a/factors.Rmd
+++ b/factors.Rmd
@@ -312,10 +312,12 @@ Instead, we can use the `n` parameter to specify how many groups (excluding othe
 
 ```{r}
 gss_cat %>%
-  mutate(relig = fct_lump(relig, n = 10, other_level = "Others")) %>%
+  mutate(relig = fct_lump(relig, n = 10)) %>%
   count(relig, sort = TRUE) %>%
   print(n = Inf)
 ```
+
+You see 9, instead of 10, groups (excluding other). Why? In this case, `relig` happens to have "Other" in its levels, and "Other" has so many counts that it is not lumped up in newly created "Other". At this point, original "Other" is one of 10 groups (excluding other). Next, `fct_lump` combines original "Other" with newly created "Other". As a result, you see 9 groups (excluding other).
 
 ### Exercises
 

--- a/factors.Rmd
+++ b/factors.Rmd
@@ -312,7 +312,7 @@ Instead, we can use the `n` parameter to specify how many groups (excluding othe
 
 ```{r}
 gss_cat %>%
-  mutate(relig = fct_lump(relig, n = 10)) %>%
+  mutate(relig = fct_lump(relig, n = 10, other_level = "Others")) %>%
   count(relig, sort = TRUE) %>%
   print(n = Inf)
 ```

--- a/factors.Rmd
+++ b/factors.Rmd
@@ -317,11 +317,11 @@ gss_cat %>%
   print(n = Inf)
 ```
 
-You see 9, instead of 10, groups (excluding other). Why? In this case, `relig` happens to have "Other" in its levels, and "Other" has so many counts that it is not lumped up in newly created "Other". At this point, original "Other" is one of 10 groups (excluding other). Next, `fct_lump` combines original "Other" with newly created "Other". As a result, you see 9 groups (excluding other).
-
 ### Exercises
 
 1.  How have the proportions of people identifying as Democrat, Republican, and
     Independent changed over time?
 
 1.  How could you collapse `rincome` into a small set of categories?
+
+1.  Notice there are 9 groups (excluding other) in the `fct_lump` example above. Why not 10? (Hint: type `?fct_lump`, and find the default for the argument `other_level` is "Other".)


### PR DESCRIPTION
As n = 10 in fct_lump, the result should have 11 rows, but has only 10 rows, because `relig` happens to have "Other" in levels.