### PR TITLE
.x, not ., is recommended in ~ formula

### DIFF
--- a/iteration.Rmd
+++ b/iteration.Rmd
@@ -548,10 +548,10 @@ The syntax for creating an anonymous function in R is quite verbose so purrr pro
 ```{r}
 models <- mtcars %>% 
   split(.$cyl) %>% 
-  map(~lm(mpg ~ wt, data = .))
+  map(~lm(mpg ~ wt, data = .x))
 ```
 
-Here I've used `.` as a pronoun: it refers to the current list element (in the same way that `i` referred to the current index in the for loop). 
+Here I've used `.x` as a pronoun: it refers to the current list element (in the same way that `i` referred to the current index in the for loop). `.x` in a one-sided formula corresponds to an argument in an anonymous function.
 
 When you're looking at many models, you might want to extract a summary statistic like the $R^2$. To do that we need to first run `summary()` and then extract the component called `r.squared`. We could do that using the shorthand for anonymous functions:
 

--- a/iteration.Rmd
+++ b/iteration.Rmd
@@ -551,14 +551,14 @@ models <- mtcars %>%
   map(~lm(mpg ~ wt, data = .x))
 ```
 
-Here I've used `.x` as a pronoun: it refers to the current list element (in the same way that `i` referred to the current index in the for loop). `.x` in a one-sided formula corresponds to an argument in an anonymous function.
+Here I've used `.x` as a pronoun: it refers to the current list element (in the same way that `i` referred to the current index in the for loop). `.x` in a one-sided formula corresponds to the first argument in an anonymous function.
 
 When you're looking at many models, you might want to extract a summary statistic like the $R^2$. To do that we need to first run `summary()` and then extract the component called `r.squared`. We could do that using the shorthand for anonymous functions:
 
 ```{r}
 models %>% 
   map(summary) %>% 
-  map_dbl(~.$r.squared)
+  map_dbl(~.x$r.squared)
 ```
 
 But extracting named components is a common operation, so purrr provides an even shorter shortcut: you can use a string.
@@ -717,7 +717,7 @@ What if you also want to vary the standard deviation? One way to do that would b
 ```{r}
 sigma <- list(1, 5, 10)
 seq_along(mu) %>% 
-  map(~rnorm(5, mu[[.]], sigma[[.]])) %>% 
+  map(~rnorm(5, mu[[.x]], sigma[[.x]])) %>% 
   str()
 ```
 
@@ -848,7 +848,7 @@ x %>%
 library(ggplot2)
 plots <- mtcars %>% 
   split(.$cyl) %>% 
-  map(~ggplot(., aes(mpg, wt)) + geom_point())
+  map(~ggplot(.x, aes(mpg, wt)) + geom_point())
 paths <- stringr::str_c(names(plots), ".pdf")
 
 pwalk(list(paths, plots), ggsave, path = tempdir())
@@ -896,20 +896,20 @@ x <- sample(10)
 x
 
 x %>% 
-  detect(~ . > 5)
+  detect(~ .x > 5)
 
 x %>% 
-  detect_index(~ . > 5)
+  detect_index(~ .x > 5)
 ```
 
 `head_while()` and `tail_while()` take elements from the start or end of a vector while a predicate is true:
 
 ```{r}
 x %>% 
-  head_while(~ . > 5)
+  head_while(~ .x > 5)
 
 x %>% 
-  tail_while(~ . > 5)
+  tail_while(~ .x > 5)
 ```
 
 ### Reduce and accumulate

--- a/iteration.Rmd
+++ b/iteration.Rmd
@@ -551,7 +551,7 @@ models <- mtcars %>%
   map(~lm(mpg ~ wt, data = .x))
 ```
 
-Here I've used `.x` as a pronoun: it refers to the current list element (in the same way that `i` referred to the current index in the for loop). `.x` in a one-sided formula corresponds to the first argument in an anonymous function.
+Here I've used `.x` as a pronoun: it refers to the current list element (in the same way that `i` referred to the current index in the for loop). `.x` in a one-sided formula corresponds to an argument in an anonymous function.
 
 When you're looking at many models, you might want to extract a summary statistic like the $R^2$. To do that we need to first run `summary()` and then extract the component called `r.squared`. We could do that using the shorthand for anonymous functions:
 
@@ -854,7 +854,7 @@ paths <- stringr::str_c(names(plots), ".pdf")
 pwalk(list(paths, plots), ggsave, path = tempdir())
 ```
 
-`walk()`, `walk2()` and `pwalk()` all invisibly return `.x`, the first argument. This makes them suitable for use in the middle of pipelines. 
+`walk()`, `walk2()` and `pwalk()` all invisibly return `.`, the first argument. This makes them suitable for use in the middle of pipelines. 
 
 ## Other patterns of for loops
 


### PR DESCRIPTION
.x is now recommended in ~ formula to avoid confusion with . in pipe