### PR TITLE
Fix unnest examples

### DIFF
--- a/model-many.Rmd
+++ b/model-many.Rmd
@@ -458,7 +458,7 @@ df %>%
       unnest(q)
     ```
 
-1.  What does this code do? Why might might it be useful?
+1.  What does this code do? Why might it be useful?
 
     ```{r, eval = FALSE}
     mtcars %>% 
@@ -548,7 +548,7 @@ The same principle applies when unnesting list-columns of data frames. You can u
 
 ### Exercises
 
-1.  Why might the `lengths()` function be useful for creating atomic
+1.  Why might the `length()` function be useful for creating atomic
     vector columns from list-columns?
     
 1.  List the most common types of vector found in a data frame. What makes

--- a/model-many.Rmd
+++ b/model-many.Rmd
@@ -207,17 +207,9 @@ broom::glance(nz_mod)
 We can use `mutate()` and `unnest()` to create a data frame with a row for each country:
 
 ```{r}
-by_country %>% 
-  mutate(glance = map(model, broom::glance)) %>% 
-  unnest(glance)
-```
-
-This isn't quite the output we want, because it still includes all the list columns. This is default behaviour when `unnest()` works on single row data frames. To suppress these columns we use `.drop = TRUE`:
-
-```{r}
 glance <- by_country %>% 
   mutate(glance = map(model, broom::glance)) %>% 
-  unnest(glance, .drop = TRUE)
+  unnest(glance)
 glance
 ```
 
@@ -266,8 +258,7 @@ We see two main effects here: the tragedies of the HIV/AIDS epidemic and the Rwa
 1.  To create the last plot (showing the data for the countries with the
     worst model fits), we needed two steps: we created a data frame with
     one row per country and then semi-joined it to the original dataset.
-    It's possible to avoid this join if we use `unnest()` instead of 
-    `unnest(.drop = TRUE)`. How?
+    It's possible to avoid this join. How?
 
 ## List-columns
 
@@ -529,30 +520,31 @@ df %>% mutate(
 tibble(x = 1:2, y = list(1:4, 1)) %>% unnest(y)
 ```
 
-This means that you can't simultaneously unnest two columns that contain different number of elements:
+This means that you can't simultaneously unnest two columns that contain incompatible number of elements:
 
 ```{r, error = TRUE}
-# Ok, because y and z have the same number of elements in
-# every row
+# Ok, because y and z have either the same number of elements or one element
+# in every row
 df1 <- tribble(
   ~x, ~y,           ~z,
    1, c("a", "b"), 1:2,
-   2, "c",           3
+   2, "c",         3:4
 )
 df1
 df1 %>% unnest(c(y, z))
 
-# Doesn't work because y and z have different number of elements
+# Doesn't work because y and z have incompatible number of elements
+# in some row
 df2 <- tribble(
   ~x, ~y,           ~z,
    1, "a",         1:2,  
-   2, c("b", "c"),   3
+   2, c("a", "b", "c"), 3:4
 )
 df2
 df2 %>% unnest(c(y, z))
 ```
 
-The same principle applies when unnesting list-columns of data frames. You can unnest multiple list-cols as long as all the data frames in each row have the same number of rows.
+The same principle applies when unnesting list-columns of data frames. You can unnest multiple list-cols as long as all the data frames in each row have the compatible number of rows.
 
 ### Exercises
 


### PR DESCRIPTION
unnest: .drop no longer works, multiple columns require not equal but compatible lengths, and some typos