### PR TITLE
Remove reference to d3heatmap

### DIFF
--- a/EDA.Rmd
+++ b/EDA.Rmd
@@ -492,7 +492,7 @@ diamonds %>%
 ```
 
 If the categorical variables are unordered, you might want to use the seriation package to simultaneously reorder the rows and columns in order to more clearly reveal interesting patterns.
-For larger plots, you might want to try the d3heatmap or heatmaply packages, which create interactive plots.
+For larger plots, you might want to try the heatmaply package, which creates interactive plots.
 
 #### Exercises
 


### PR DESCRIPTION
[From d3heatmap’s readme](https://github.com/talgalili/d3heatmap/blob/509239650129309fb3ac01f40f9b4fafa524ea30/README.md):

> d3heatmap is not actively maintained. You might consider using a newer heatmap package like [heatmaply](https://github.com/talgalili/heatmaply).