### PR TITLE
Fix str_to_upper’s default locale

### DIFF
--- a/strings.Rmd
+++ b/strings.Rmd
@@ -177,7 +177,7 @@ str_to_upper(c("i", "ı"), locale = "tr")
 
 The locale is specified as a ISO 639 language code, which is a two or three letter abbreviation.
 If you don't already know the code for your language, [Wikipedia](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) has a good list.
-If you leave the locale blank, it will use the current locale, as provided by your operating system.
+If you leave the locale blank, it will use English.
 
 Another important operation that's affected by the locale is sorting.
 The base R `order()` and `sort()` functions sort strings using the current locale.


### PR DESCRIPTION
According to [stringr’s reference](https://stringr.tidyverse.org/reference/case.html), the locale defaults to English:

> **locale**: Locale to use for translations. Defaults to "en" (English) to ensure consistent default ordering across platforms.