### PR TITLE
Remove dmonths() exercise

### DIFF
--- a/datetimes.Rmd
+++ b/datetimes.Rmd
@@ -539,17 +539,15 @@ knitr::include_graphics("diagrams/datetimes-arithmetic.png")
 
 ### Exercises
 
-1.  Why is there `months()` but no `dmonths()`?
-
-2.  Explain `days(overnight * 1)` to someone who has just started learning R.
+1.  Explain `days(overnight * 1)` to someone who has just started learning R.
     How does it work?
 
-3.  Create a vector of dates giving the first day of every month in 2015.
+2.  Create a vector of dates giving the first day of every month in 2015.
     Create a vector of dates giving the first day of every month in the *current* year.
 
-4.  Write a function that given your birthday (as a date), returns how old you are in years.
+3.  Write a function that given your birthday (as a date), returns how old you are in years.
 
-5.  Why can't `(today() %--% (today() + years(1))) / months(1)` work?
+4.  Why can't `(today() %--% (today() + years(1))) / months(1)` work?
 
 ## Time zones
 


### PR DESCRIPTION
lubridate provides [`dmonths()`](https://lubridate.tidyverse.org/reference/duration.html) and it’s even linked on [r4ds.had.co.nz](https://r4ds.had.co.nz/dates-and-times.html#exercises-49). Resolves #942.