### PR TITLE
Change "with a" to "that have" for clarity

### DIFF
--- a/data-visualize.Rmd
+++ b/data-visualize.Rmd
@@ -444,7 +444,7 @@ ggplot(data = mpg) +
 ```
 
 Here `geom_smooth()` separates the cars into three lines based on their `drv` value, which describes a car's drive train.
-One line describes all of the points with a `4` value, one line describes all of the points with an `f` value, and one line describes all of the points with an `r` value.
+One line describes all of the points that have a `4` value, one line describes all of the points that have an `f` value, and one line describes all of the points that have an `r` value.
 Here, `4` stands for four-wheel drive, `f` for front-wheel drive, and `r` for rear-wheel drive.
 
 If this sounds strange, we can make it more clear by overlaying the lines on top of the raw data and then colouring everything according to `drv`.


### PR DESCRIPTION
In the section 3.6 on Geometrical objects, I momentarily understood that it was saying that one line is describing the entirety of the values in the data-set through the 4 value. This is unlikely, due to the context, but it happened to me before realizing that wasn't the case. This small change could avoid that misunderstanding.