### PR TITLE
Defined "word" in exercise 14.4.4.1.3

### DIFF
--- a/strings.Rmd
+++ b/strings.Rmd
@@ -453,7 +453,7 @@ Recommendation to make a function, and think about testing it --- don't need for
 2.  Implement a simple version of `str_to_lower()` using `str_replace_all()`.
 
 3.  Switch the first and last letters in `words`.
-    Which of those strings are still words?
+    Which of those strings are still `words`?
 
 ## Extract full matches
 


### PR DESCRIPTION
Changed "Which of those strings are still words?" to "Which of those strings are still `words`?". This gives a big hint to the reader, hopefully letting them figure out how to solve this part of the exercise in an automatic way, rather than trying to eyeball an answer.