### PR TITLE
consistent with treatment of *alpha* ?

### DIFF
--- a/data-visualize.Rmd
+++ b/data-visualize.Rmd
@@ -186,7 +186,7 @@ ggplot(data = mpg) +
   geom_point(mapping = aes(x = displ, y = hwy, size = class))
 ```
 
-Or we could have mapped `class` to the *alpha* aesthetic, which controls the transparency of the points, or to the shape aesthetic, which controls the shape of the points.
+Or we could have mapped `class` to the *alpha* aesthetic, which controls the transparency of the points, or to the *shape* aesthetic, which controls the shape of the points.
 
 ```{r, out.width = "50%", fig.align = 'default', warning = FALSE, fig.asp = 1/2, fig.cap ="", fig.alt = "Two scatterplots next to each other, both visualizing highway fuel efficiency versus engine size of cars in ggplot2::mpg and showing a negative association. In the plot on the left class is mapped to the alpha aesthetic, resulting in different transparency levels for each level of class. In the plot on the right class is mapped the shape aesthetic, resulting in different plotting character shapes for each level of class. Each plot comes with a legend that shows the mapping between alpha level or shape and levels of the class variable."}
 # Left


### PR DESCRIPTION
add emphasis, to be consistent with treatment of *alpha* ? ...

row189 : "or to the shape aesthetic" --> "or to the *shape* aesthetic"

[sorry if I've forgotten how to use github]