### PR TITLE
Fix URLs + add xaringan

### DIFF
--- a/rmarkdown-formats.Rmd
+++ b/rmarkdown-formats.Rmd
@@ -8,7 +8,7 @@ There are two ways to set the output of a document:
 
 1.  Permanently, by modifying the YAML header:
 
-    ``` {.yaml}
+    ``` yaml
     title: "Viridis Demo"
     output: html_document
     ```
@@ -39,7 +39,7 @@ For example, to figure out what parameters you can set with `html_document`, loo
 To override the default parameter values, you need to use an expanded `output` field.
 For example, if you wanted to render an `html_document` with a floating table of contents, you'd use:
 
-``` {.yaml}
+``` yaml
 output:
   html_document:
     toc: true
@@ -48,7 +48,7 @@ output:
 
 You can even render to multiple outputs by supplying a list of formats:
 
-``` {.yaml}
+``` yaml
 output:
   html_document:
     toc: true
@@ -85,7 +85,7 @@ knitr::opts_chunk$set(echo = FALSE)
 
 For `html_document`s another option is to make the code chunks hidden by default, but visible with a click:
 
-``` {.yaml}
+``` yaml
 output:
   html_document:
     code_folding: hide
@@ -113,7 +113,7 @@ If this starts to happen, it's a good time to learn Git and GitHub.
 Learning Git and GitHub is definitely painful at first, but the collaboration payoff is huge.
 As mentioned earlier, Git and GitHub are outside the scope of the book, but there's one tip that's useful if you're already using them: use both `html_notebook` and `github_document` outputs:
 
-``` {.yaml}
+``` yaml
 output:
   html_notebook: default
   github_document: default
@@ -138,12 +138,14 @@ R Markdown comes with three presentation formats built-in:
 
 3.  `beamer_presentation` - PDF presentation with LaTeX Beamer.
 
-Two other popular formats are provided by packages:
+Three other popular formats are provided by packages:
 
-1.  `revealjs::revealjs_presentation` - HTML presentation with reveal.js.
-    Requires the **revealjs** package.
+1.  **xaringan**, <https://slides.yihui.org/xaringan>, is an R Markdown extension based on the JavaScript library remark.js to generate HTML5 presentations.
 
-2.  **rmdshower**, <https://github.com/MangoTheCat/rmdshower>, provides a wrapper around the **shower**, <https://github.com/shower/shower>, presentation engine
+2.  `revealjs::revealjs_presentation` - HTML presentation with reveal.js.
+    Requires the **revealjs** package, <https://github.com/rstudio/revealjs>.
+
+3.  **rmdshower**, <https://github.com/MangoTheCat/rmdshower>, provides a wrapper around the **shower**, <https://github.com/shower/shower>, presentation engine
 
 ## Dashboards
 
@@ -167,7 +169,7 @@ cat(readr::read_file("rmarkdown/dashboard.Rmd"))
 ```
 
 Flexdashboard also provides simple tools for creating sidebars, tabsets, value boxes, and gauges.
-To learn more about flexdashboard visit <http://rmarkdown.rstudio.com/flexdashboard/>.
+To learn more about flexdashboard visit <https://pkgs.rstudio.com/flexdashboard>.
 
 ## Interactivity
 
@@ -193,15 +195,15 @@ All the details are wrapped inside the package, so you don't need to worry about
 
 There are many packages that provide htmlwidgets, including:
 
--   **dygraphs**, <http://rstudio.github.io/dygraphs/>, for interactive time series visualisations.
+-   **dygraphs**, [http://rstudio.github.io/dygraphs](http://rstudio.github.io/dygraphs/){.uri}, for interactive time series visualisations.
 
--   **DT**, <http://rstudio.github.io/DT/>, for interactive tables.
+-   **DT**, [http://rstudio.github.io/DT/](http://rstudio.github.io/DT){.uri}, for interactive tables.
 
--   **threejs**, <https://github.com/bwlewis/rthreejs> for interactive 3d plots.
+-   **threejs**, [http://bwlewis.github.io/rthreejs](http://bwlewis.github.io/rthreejs/){.uri} for interactive 3d plots.
 
--   **DiagrammeR**, <http://rich-iannone.github.io/DiagrammeR/> for diagrams (like flow charts and simple node-link diagrams).
+-   **DiagrammeR**, <http://rich-iannone.github.io/DiagrammeR> for diagrams (like flow charts and simple node-link diagrams).
 
-To learn more about htmlwidgets and see a more complete list of packages that provide them visit <http://www.htmlwidgets.org/>.
+To learn more about htmlwidgets and see a more complete list of packages that provide them visit <http://www.htmlwidgets.org>.
 
 ### Shiny
 
@@ -212,7 +214,7 @@ An alternative approach is to use **shiny**, a package that allows you to create
 
 To call Shiny code from an R Markdown document, add `runtime: shiny` to the header:
 
-``` {.yaml}
+``` yaml
 title: "Shiny Web App"
 output: html_document
 runtime: shiny
@@ -239,7 +241,7 @@ This introduces a logistical issue: Shiny apps need a Shiny server to be run onl
 When you run shiny apps on your own computer, shiny automatically sets up a shiny server for you, but you need a public facing shiny server if you want to publish this sort of interactivity online.
 That's the fundamental trade-off of shiny: you can do anything in a shiny document that you can do in R, but it requires someone to be running R.
 
-Learn more about Shiny at <http://shiny.rstudio.com/>.
+Learn more about Shiny at <http://shiny.rstudio.com>.
 
 ## Websites
 
@@ -258,19 +260,19 @@ With a little additional infrastructure you can use R Markdown to generate a com
 Execute `rmarkdown::render_site()` to build `_site`, a directory of files ready to deploy as a standalone static website, or if you use an RStudio Project for your website directory.
 RStudio will add a Build tab to the IDE that you can use to build and preview your site.
 
-Read more at <http://rmarkdown.rstudio.com/rmarkdown_websites.html>.
+Read more at <https://bookdown.org/yihui/rmarkdown/rmarkdown-site.html>.
 
 ## Other formats
 
 Other packages provide even more output formats:
 
--   The **bookdown** package, <https://github.com/rstudio/bookdown>, makes it easy to write books, like this one.
+-   The **bookdown** package, <https://pkgs.rstudio.com/bookdown>, makes it easy to write books, like this one.
     To learn more, read [*Authoring Books with R Markdown*](https://bookdown.org/yihui/bookdown/), by Yihui Xie, which is, of course, written in bookdown.
     Visit <http://www.bookdown.org> to see other bookdown books written by the wider R community.
 
--   The **prettydoc** package, <https://github.com/yixuan/prettydoc/>, provides lightweight document formats with a range of attractive themes.
+-   The **prettydoc** package, [https://prettydoc.statr.me](https://prettydoc.statr.me/){.uri}, provides lightweight document formats with a range of attractive themes.
 
--   The **rticles** package, <https://github.com/rstudio/rticles>, compiles a selection of formats tailored for specific scientific journals.
+-   The **rticles** package, <https://pkgs.rstudio.com/rticles>, compiles a selection of formats tailored for specific scientific journals.
 
 See <http://rmarkdown.rstudio.com/formats.html> for a list of even more formats.
 You can also create your own by following the instructions at <http://rmarkdown.rstudio.com/developer_custom_formats.html>.
@@ -286,8 +288,8 @@ To learn more about effective communication in these different formats I recomme
 
 -   I haven't taken it myself, but I've heard good things about Matt McGarrity's online course on public speaking: <https://www.coursera.org/learn/public-speaking>.
 
--   If you are creating a lot of dashboards, make sure to read Stephen Few's [Information Dashboard Design: The Effective Visual Communication of Data](https://amzn.com/0596100167).
+-   If you are creating a lot of dashboards, make sure to read Stephen Few's [*Information Dashboard Design: The Effective Visual Communication of Data*](https://www.amazon.com/Information-Dashboard-Design-Effective-Communication/dp/0596100167).
     It will help you create dashboards that are truly useful, not just pretty to look at.
 
 -   Effectively communicating your ideas often benefits from some knowledge of graphic design.
-    [*The Non-Designer's Design Book*](http://amzn.com/0133966151) is a great place to start.
+    Robin Williams' [*The Non-Designer's Design Book*](https://www.amazon.com/Non-Designers-Design-Book-4th/dp/0133966151) is a great place to start.


### PR DESCRIPTION
Fixes a bunch of URLs in the rmarkdown-formats chapter. Closes #969.

Also adds xaringan since it seemed to be missing from the list of presentation formats.