### PR TITLE
Added link ggplot2 cheat sheet mention

### DIFF
--- a/data-visualize.Rmd
+++ b/data-visualize.Rmd
@@ -682,7 +682,7 @@ There are three reasons you might need to use a stat explicitly:
 
 ggplot2 provides over 20 stats for you to use.
 Each stat is a function, so you can get help in the usual way, e.g. `?stat_bin`.
-To see a complete list of stats, try the ggplot2 cheatsheet.
+To see a complete list of stats, try the ggplot2 cheatsheet, <http://rstudio.com/resources/cheatsheets>.
 
 ### Exercises
 

--- a/data-visualize.Rmd
+++ b/data-visualize.Rmd
@@ -682,7 +682,7 @@ There are three reasons you might need to use a stat explicitly:
 
 ggplot2 provides over 20 stats for you to use.
 Each stat is a function, so you can get help in the usual way, e.g. `?stat_bin`.
-To see a complete list of stats, try the ggplot2 cheatsheet, <http://rstudio.com/resources/cheatsheets>.
+To see a complete list of stats, try the [ggplot2 cheatsheet](<http://rstudio.com/resources/cheatsheets>).
 
 ### Exercises
 


### PR DESCRIPTION
Added the link to http://rstudio.com/resources/cheatsheets to the mention under "3.7 Statistical transformations" in order for people to be able to jump to the correct source directly, instead of having to navigating back up.

Didn't add it as an inline link in consideration of offline (book) readers.