### PR TITLE
Many Models: Fixed a reference typo

### DIFF
--- a/extra/model/model-many.Rmd
+++ b/extra/model/model-many.Rmd
@@ -431,7 +431,7 @@ sim %>%
   mutate(sims = invoke_map(f, params, n = 10))
 ```
 
-Note that technically `sim` isn't homogeneous because it contains both double and integer vectors.
+Note that technically `sims` isn't homogeneous because it contains both double and integer vectors.
 However, this is unlikely to cause many problems since integers and doubles are both numeric vectors.
 
 ### From multivalued summaries


### PR DESCRIPTION
Fixed a small typo. We want to refer to the column `sims` not being homogenous, as opposed to `sim` which is the name of the entire tribble.