### PR TITLE
changed branch designator from master->main

### DIFF
--- a/_output.yaml
+++ b/_output.yaml
@@ -14,7 +14,7 @@ bookdown::gitbook:
       before: |
         <li><strong><a href="./">R for Data Science</a></strong></li>
     edit:
-      link: https://github.com/hadley/r4ds/edit/master/%s
+      link: https://github.com/hadley/r4ds/edit/main/%s
       text: "Edit"
     sharing: no
   css: r4ds.css

--- a/rmarkdown.Rmd
+++ b/rmarkdown.Rmd
@@ -128,7 +128,7 @@ If you forget, you can get to a handy reference sheet with *Help \> Markdown Qui
     b.  Add a horizontal rule.
     c.  Add a block quote.
 
-3.  Copy and paste the contents of `diamond-sizes.Rmd` from <https://github.com/hadley/r4ds/tree/master/rmarkdown> in to a local R Markdown document.
+3.  Copy and paste the contents of `diamond-sizes.Rmd` from <https://github.com/hadley/r4ds/tree/main/rmarkdown> in to a local R Markdown document.
     Check that you can run it, then add text after the frequency polygon that describes its most striking features.
 
 ## Code chunks
@@ -343,7 +343,7 @@ comma(.12358124331)
 1.  Add a section that explores how diamond sizes vary by cut, colour, and clarity.
     Assume you're writing a report for someone who doesn't know R, and instead of setting `echo = FALSE` on each chunk, set a global option.
 
-2.  Download `diamond-sizes.Rmd` from <https://github.com/hadley/r4ds/tree/master/rmarkdown>.
+2.  Download `diamond-sizes.Rmd` from <https://github.com/hadley/r4ds/tree/main/rmarkdown>.
     Add a section that describes the largest 20 diamonds, including a table that displays their most important attributes.
 
 3.  Modify `diamonds-sizes.Rmd` to use `comma()` to produce nicely formatted output.


### PR DESCRIPTION
Some minor changes to complete the master->main branch renaming.

I assume that these changes will be reflected in the "Edit this page" link in each chapter:

![master-main](https://user-images.githubusercontent.com/35631/152423161-c0ce98aa-80a1-4603-9d91-22545f3ecb28.png)

There are two further locations where this pops up, which I **didn't**  update:

- the Travis badge in the `README.md` I've left that untouched, because it would change the build status to _unknown_. Travis needs some TLC anyway, because they've changed something and no longer support Travis.org ... bla (sounds like a nightmare to deal with)
- `.github/workflows/build_book.yaml` configuration contains references to both main and master. Again, don't want to fiddle with it.

Finally, fwiw: I assign the copyright of this contribution to Hadley Wickham