### PR TITLE
Update reference to ggplot2 book

### DIFF
--- a/communicate-plots.Rmd
+++ b/communicate-plots.Rmd
@@ -683,9 +683,8 @@ The chunk label is used to generate the file name of the graphic on disk, so nam
 
 ## Learning more
 
-The absolute best place to learn more is the ggplot2 book: [*ggplot2: Elegant graphics for data analysis*](https://amzn.com/331924275X).
+The absolute best place to learn more is the ggplot2 book: [*ggplot2: elegant graphics for data analysis*](https://ggplot2-book.org).
 It goes into much more depth about the underlying theory, and has many more examples of how to combine the individual pieces to solve practical problems.
-Unfortunately, the book is not available online for free, although you can find the source code at <https://github.com/hadley/ggplot2-book>.
 
 Another great resource is the ggplot2 extensions gallery <https://exts.ggplot2.tidyverse.org/gallery/>.
 This site lists many of the packages that extend ggplot2 with new geoms and scales.


### PR DESCRIPTION
[The book is now available online for free](https://ggplot2-book.org) (at least the work-in-progress 3rd edition), so I removed the obsolete sentence and updated the link.