### PR TITLE
Replace "data frame" with "`data.frame`" in the Tibbles chapter

### DIFF
--- a/tibble.Rmd
+++ b/tibble.Rmd
@@ -22,7 +22,7 @@ library(tidyverse)
 ## Creating tibbles
 
 Almost all of the functions that you'll use in this book produce tibbles, as tibbles are one of the unifying features of the tidyverse.
-Most other R packages use regular data frames, so you might want to coerce a data frame to a tibble.
+Most other R packages use regular `data.frame`s, so you might want to coerce a `data.frame` to a tibble.
 You can do that with `as_tibble()`:
 
 ```{r}
@@ -182,17 +182,17 @@ class(as.data.frame(tb))
 
 The main reason that some older functions don't work with tibble is the `[` function.
 We don't use `[` much in this book because for data frames, `dplyr::filter()` and `dplyr::select()` typically allow you to solve the same problems with clearer code.
-With base R data frames, `[` sometimes returns a data frame, and sometimes returns a vector.
+With base R `data.frame`s, `[` sometimes returns a `data.frame`, and sometimes returns a vector.
 With tibbles, `[` always returns another tibble.
 
 ## Exercises
 
 1.  How can you tell if an object is a tibble?
-    (Hint: try printing `mtcars`, which is a regular data frame).
+    (Hint: try printing `mtcars`, which is a regular `data.frame`).
 
 2.  Compare and contrast the following operations on a `data.frame` and equivalent tibble.
     What is different?
-    Why might the default data frame behaviours cause you frustration?
+    Why might the default `data.frame` behaviours cause you frustration?
 
     ```{r, eval = FALSE}
     df <- data.frame(abc = 1, xyz = "a")


### PR DESCRIPTION
In the opening of the Tibbles chapter, it is said

> when I want to draw particular attention to R’s built-in data frame, I’ll call them data.frames

so it could aid clarity to do that for the remainder of the page.