### PR TITLE
Correct `lubridate::as_datetime()`

### DIFF
--- a/vectors.qmd
+++ b/vectors.qmd
@@ -722,7 +722,7 @@ attributes(y)
 POSIXlts are rare inside the tidyverse.
 They do crop up in base R, because they are needed to extract specific components of a date, like the year or month.
 Since lubridate provides helpers for you to do this instead, you don't need them.
-POSIXct's are always easier to work with, so if you find you have a POSIXlt, you should always convert it to a regular date time with `lubridate::as_date_time()`.
+POSIXct's are always easier to work with, so if you find you have a POSIXlt, you should always convert it to a regular date time with `lubridate::as_datetime()`.
 
 ### Tibbles
 


### PR DESCRIPTION
Correct `lubridate::as_date_time()` to  `lubridate::as_datetime()` (unless this is a new function name coming up in lubridate).