### PR TITLE
Fix typos

### DIFF
--- a/functions.qmd
+++ b/functions.qmd
@@ -311,7 +311,7 @@ It's a great idea to capture that sort of thinking in a comment.
 3.  Compare and contrast `rnorm()` and `MASS::mvrnorm()`.
     How could you make them more consistent?
 
-4.  Make a case for why `norm_r()`, `norm_d()` etc would be better than `rnorm()`, `dnorm()`.
+4.  Make a case for why `norm_r()`, `norm_d()` etc. would be better than `rnorm()`, `dnorm()`.
     Make a case for the opposite.
 
 ## Conditional execution {#sec-conditional-execution}

--- a/joins.qmd
+++ b/joins.qmd
@@ -423,7 +423,7 @@ You can control this with the `suffix` argument.
 What happens if the variable name is different?
 It turns out that `join_by(key)` is a shorthand for `join_by(tailnum == tailnum)`, which is in turn shorthand for `join_by(x$tailnum == y$tailnum)`.
 
-For example, there are two ways to join the `flight2` and `airports` table: either by `dest` or `origin:`
+For example, there are two ways to join the `flight2` and `airports` table: either by `dest` or `origin`:
 
 ```{r}
 flights2 |> 
@@ -464,7 +464,7 @@ We now prefer `join_by()` as it's a more flexible specification that supports ma
 
 4.  What weather conditions make it more likely to see a delay?
 
-5.  What happened on June 13 2013?
+5.  What happened on 13 June 2013?
     Display the spatial pattern of delays, and then use Google to cross-reference with the weather.
 
     ```{r}

--- a/rmarkdown-formats.qmd
+++ b/rmarkdown-formats.qmd
@@ -79,12 +79,12 @@ There are a number of basic variations on that theme, generating different types
 
 -   `odt_document` for OpenDocument Text documents (`.odt`).
 
--   `rtf_document` for Rich Text Format (`.rtf`) documents.
+-   `rtf_document` for Rich Text Format documents (`.rtf`).
 
 -   `md_document` for a Markdown document.
     This isn't typically useful by itself, but you might use it if, for example, your corporate CMS or lab wiki uses markdown.
 
--   `github_document`: this is a tailored version of `md_document` designed for sharing on GitHub.
+-   `github_document` is a tailored version of `md_document` designed for sharing on GitHub.
 
 Remember, when generating a document to share with decision makers, you can turn off the default display of code by setting global options in the setup chunk:
 


### PR DESCRIPTION
I fixed inline R codes and file type inconsistency in sentences at [https://r4ds.hadley.nz/rmarkdown-formats.html#documents](https://r4ds.hadley.nz/rmarkdown-formats.html#documents).