### PR TITLE
Fix plaintext typos

### DIFF
--- a/logicals.qmd
+++ b/logicals.qmd
@@ -200,7 +200,7 @@ In R, `&` is "and", `|` is "or", and `!` is "not", and `xor()` is exclusive or[^
 
 [^logicals-2]: That is, `xor(x, y)` is true if x is true, or y is true, but not both.
     This is how we usually use "or" In English.
-    Both is not usually an acceptable answer to the question "would you like ice cream or cake?".
+    "Both" is not usually an acceptable answer to the question "would you like ice cream or cake?".
 
 ```{r}
 #| label: fig-bool-ops

--- a/strings.qmd
+++ b/strings.qmd
@@ -312,7 +312,7 @@ babynames |>
   geom_line()
 ```
 
-(Note that this gives us the proportion of names that contain an x; if you wanted the proportion of babies with a name containing an x, you'd need to perform a weighted mean).
+(Note that this gives us the proportion of names that contain an x; if you wanted the proportion of babies with a name containing an x, you'd need to perform a weighted mean.)
 
 ### Introduction to regular expressions
 
@@ -325,8 +325,7 @@ str_detect(c("x", "X"), "x")
 
 In general, any letter or number will match exactly, but punctuation characters like `.`, `+`, `*`, `[`, `]`, `?`, often have special meanings[^strings-8].
 For example, `.`
-will match any character[^strings-9], so `"a."` will match any string that contains an "a" followed by another character
-:
+will match any character[^strings-9], so `"a."` will match any string that contains an "a" followed by another character:
 
 [^strings-8]: You'll learn how to escape this special behaviour in @sec-regexp-escaping.
 


### PR DESCRIPTION
I added a missing `"` `"` and fixed minor punctuations in plaintext.