### PR TITLE
Fix pipe terminology in plaintext

### DIFF
--- a/data-tidy.qmd
+++ b/data-tidy.qmd
@@ -199,7 +199,7 @@ billboard |>
 ```
 
 What happens if a song is in the top 100 for less than 76 weeks?
-Take 2 Pac's "Baby Don't Cry", for example.
+Take 2Pac's "Baby Don't Cry", for example.
 The above output suggests that it was only the top 100 for 7 weeks, and all the remaining weeks are filled in with missing values.
 These `NA`s don't really represent unknown observations; they're forced to exist by the structure of the dataset[^data-tidy-1], so we can ask `pivot_longer()` to get rid of them by setting `values_drop_na = TRUE`:
 

--- a/index.qmd
+++ b/index.qmd
@@ -8,8 +8,8 @@ These are the skills that allow data science to happen, and here you will find t
 You'll learn how to use the grammar of graphics, literate programming, and reproducible research to save time.
 You'll also learn how to manage cognitive resources to facilitate discoveries when wrangling, visualising, and exploring data.
 
-This website is (and will always be) **free to use**, and is licensed under the [Creative Commons Attribution-NonCommercial-NoDerivs 3.0](http://creativecommons.org/licenses/by-nc-nd/3.0/us/) License.
-If you'd like a **physical copy** of the book, you can order it from [amazon](http://amzn.to/2aHLAQ1); it was published by O'Reilly in January 2017.
+This website is (and will always be) **free to use**, and is licensed under the [Creative Commons Attribution-NonCommercial-NoDerivs 3.0](https://creativecommons.org/licenses/by-nc-nd/3.0/us/) License.
+If you'd like a **physical copy** of the book, you can order it from [amazon](https://amzn.to/2aHLAQ1); it was published by O'Reilly in January 2017.
 If you'd like to **give back** please make a donation to [Kākāpō Recovery](https://www.doc.govt.nz/kakapo-donate): the [kākāpō](https://www.youtube.com/watch?v=9T1vfsHYiKY) (which appears on the cover of R4DS) is a critically endangered native NZ parrot; there are only 199 left.
 
 Please note that R4DS uses a [Contributor Code of Conduct](https://contributor-covenant.org/version/2/0/CODE_OF_CONDUCT.html).

--- a/joins.qmd
+++ b/joins.qmd
@@ -82,7 +82,7 @@ These datasets are all connected via the `flights` data frame because the `tailn
 -   `flights$tailnum` connects to primary key `planes$tailnum`.
 -   `flights$carrier` connects to primary key `airlines$carrer`.
 -   `flights$origin` connects to primary key `airports$faa`.
--   `flights$dest` connects to primary key `airports$faa` .
+-   `flights$dest` connects to primary key `airports$faa`.
 -   `flights$origin`-`flights$time_hour` connects to primary key `weather$origin`-`weather$time_hour`.
 
 We can also draw these relationships, as in @fig-flights-relationships.
@@ -280,7 +280,7 @@ Note that the `year` variables are disambiguated in the output with a suffix, wh
 
 `join_by(tailnum)` is short for `join_by(tailnum == tailnum)`.
 This fuller form is important because it's how you specify different join keys in each table.
-For example, there are two ways to join the `flight2` and `airports` table: either by `dest` or `origin:`
+For example, there are two ways to join the `flight2` and `airports` table: either by `dest` or `origin`:
 
 ```{r}
 flights2 |> 
@@ -400,7 +400,7 @@ flights2 |>
 
 Now that you've used joins a few times it's time to learn more about how they work, focusing on how each row in `x` matches zero, one, or more rows in `y`.
 We'll begin by using @fig-join-setup to introduce a visual representation of the two simple tibbles defined below.
-In these examples we'll use a single key called `key` and a single value column (`val_x` and `val_y)`, but the ideas all generalize to multiple keys and multiple values.
+In these examples we'll use a single key called `key` and a single value column (`val_x` and `val_y`), but the ideas all generalize to multiple keys and multiple values.
 
 ```{r}
 x <- tribble(
@@ -573,7 +573,7 @@ To understand what's going let's first narrow our focus to the `inner_join()` an
 #| fig-cap: > 
 #|   The three key ways a row in `x` can match. `x1` matches
 #|   one row in `y`, `x2` matches two rows in `y`, `x3` matches
-#|   zero rows in y. Note that while there are three rows in
+#|   zero rows in `y`. Note that while there are three rows in
 #|   `x` and three rows in the output, there isn't a direct
 #|   correspondence between the rows.
 #| fig-alt: >
@@ -598,7 +598,7 @@ In principle, this means that there are no guarantees about the number of rows i
 -   There might be the same number of rows if some rows don't match any rows, and exactly the same number of rows match two rows in `y`!!
 
 Row expansion is a fundamental property of joins, but it's dangerous because it might by hidden.
-To avoid this problem, dplyr will warn whenever there are multiple matches:
+To avoid this problem, dplyr will warn you whenever there are multiple matches:
 
 ```{r}
 df1 <- tibble(key = c(1, 2, 3), val_x = c("x1", "x2", "x3"))
@@ -815,7 +815,7 @@ df |> left_join(df, join_by(id < id))
 
 Rolling joins are a special type of inequality join where instead of getting *every* row that satisfies the inequality, you get just the closest row, as in @fig-join-closest.
 You can turn any inequality join into a rolling join by adding `closest()`.
-For example `join_by(closest(x <= y))` matches the smallest `y` that's greater than or equal to x, and `join_by(closest(x > y))` matches the biggest `y` that's less than `x`.
+For example `join_by(closest(x <= y))` matches the smallest `y` that's greater than or equal to `x`, and `join_by(closest(x > y))` matches the biggest `y` that's less than `x`.
 
 ```{r}
 #| label: fig-join-closest

--- a/logicals.qmd
+++ b/logicals.qmd
@@ -267,7 +267,7 @@ This code doesn't error but it also doesn't seem to have worked.
 What's going on?
 Here R first evaluates `month == 11` creating a logical vector, which we call `nov`.
 It computes `nov | 12`.
-When you use a number with a logical operator it converts everything apart from 0 to TRUE, so this is equivalent to `nov | TRUE` which will always be `TRUE`, so every row will be selected:
+When you use a number with a logical operator it converts everything apart from 0 to `TRUE`, so this is equivalent to `nov | TRUE` which will always be `TRUE`, so every row will be selected:
 
 ```{r}
 flights |> 

--- a/preface-2e.qmd
+++ b/preface-2e.qmd
@@ -17,7 +17,7 @@ Welcome to the second edition of "R for Data Science".
 -   The modeling part has been removed.
     For modeling, we recommend using packages from [tidymodels](https://www.tidymodels.org/) and reading [Tidy Modeling with R](https://www.tmwr.org/) by Max Kuhn and Julia Silge to learn more about them.
 
--   We've switched from the magrittr pipe to the base pipe.
+-   We've switched from the magrittr pipe to the native pipe.
 
 ## Acknowledgements {.unnumbered}
 

--- a/rmarkdown-formats.qmd
+++ b/rmarkdown-formats.qmd
@@ -156,7 +156,7 @@ Three other popular formats are provided by packages:
 2.  `revealjs::revealjs_presentation` - HTML presentation with reveal.js.
     Requires the **revealjs** package, <https://github.com/rstudio/revealjs>.
 
-3.  **rmdshower**, <https://github.com/MangoTheCat/rmdshower>, provides a wrapper around the **shower**, <https://github.com/shower/shower>, presentation engine
+3.  **rmdshower**, <https://github.com/MangoTheCat/rmdshower>, provides a wrapper around the **shower**, <https://github.com/shower/shower>, presentation engine.
 
 ## Dashboards
 

--- a/workflow-pipes.qmd
+++ b/workflow-pipes.qmd
@@ -95,8 +95,8 @@ mtcars %>%
 ```
 
 For simple cases `|>` and `%>%` behave identically.
-So why do we recommend the base pipe?
-Firstly, because it's part of base R, it's always available for you to use, even when you're not using the tidyverse.
+So why do we recommend the native pipe?
+Firstly, because the native pipe is a part of base R, it's always available for you to use, even when you're not using the tidyverse.
 Secondly, `|>` is quite a bit simpler than `%>%`: in the time between the invention of `%>%` in 2014 and the inclusion of `|>` in R 4.1.0 in 2021, we gained a better understanding of the pipe.
 This allowed the base implementation to jettison infrequently used and less important features.
 
@@ -109,7 +109,7 @@ But they're still good to know about even if you've never used `%>%` because you
 -   By default, the pipe passes the object on its left hand side to the first argument of the function on the right-hand side.
     `%>%` allows you change the placement with a `.` placeholder.
     For example, `x %>% f(1)` is equivalent to `f(x, 1)` but `x %>% f(1, .)` is equivalent to `f(1, x)`.
-    R 4.2.0 added a `_` placeholder to the base pipe, with one additional restriction: the argument has to be named.
+    R 4.2.0 added a `_` placeholder to the native pipe, with one additional restriction: the argument has to be named.
     For example, `x |> f(1, y = _)` is equivalent to `f(1, y = x)`.
 
 -   The `|>` placeholder is deliberately simple and can't replicate many features of the `%>%` placeholder: you can't pass it to multiple arguments, and it doesn't have any special behavior when the placeholder is used inside another function.
@@ -125,6 +125,6 @@ But they're still good to know about even if you've never used `%>%` because you
 
 -   `%>%` allows you to drop the parentheses when calling a function with no other arguments; `|>` always requires the parentheses.
 
--   `%>%` allows you to start a pipe with `.` to create a function rather than immediately executing the pipe; this is not supported by the base pipe.
+-   `%>%` allows you to start a pipe with `.` to create a function rather than immediately executing the pipe; this is not supported by the native pipe.
 
-Luckily there's no need to commit entirely to one pipe or the other --- you can use the base pipe for the majority of cases where it's sufficient, and use the magrittr pipe when you really need its special features.
+Luckily there's no need to commit entirely to one pipe or the other --- you can use the native pipe for the majority of cases where it's sufficient, and use the magrittr pipe when you really need its special features.


### PR DESCRIPTION
Co-Authored-By: Betul Turkoglu <79486373+betulturkoglu@users.noreply.github.com>

We proofread the book for the third time and
- Since `|>` is referred as "native pipe" in [RStudio Options](https://r4ds.hadley.nz/workflow-pipes.html#fig-pipe-options) and is also explained that it is a part of base R in the book, we think it would be better to say `"native pipe"` instead of `"base pipe"` in plaintext to keep the terminology consistent.
- Fixed plaintext typos and inline R codes.