### PR TITLE
Output of mutate w/ across gets same *name* as input

### DIFF
--- a/iteration.qmd
+++ b/iteration.qmd
@@ -198,7 +198,7 @@ df %>% summarise(
 ```
 
 The `.names` argument is particularly important when you use `across()` with `mutate()`.
-By default the outputs of `across()` are given the same numbers as the inputs.
+By default the outputs of `across()` are given the same names as the inputs.
 This means that `across()` inside of `mutate()` will replace existing columns:
 
 ```{r}


### PR DESCRIPTION
iteration chapter erroneously says numbers in place of names.