### PR TITLE
fig_alt fix: color -> size

### DIFF
--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -221,7 +221,7 @@ We get a *warning* here: mapping an unordered variable (`class`) to an ordered a
 #|   Scatterplot of highway fuel efficiency versus engine size of cars that 
 #|   shows a negative association. The points representing each car are sized 
 #|   according to the class of the car. The legend on the right of the plot 
-#|   shows the mapping between colors and levels of the class variable -- going 
+#|   shows the mapping between sizes and levels of the class variable -- going 
 #|   from small to large: 2seater, compact, midsize, minivan, pickup, or suv.
 
 ggplot(data = mpg) + 


### PR DESCRIPTION
I could be wrong, but the legend description seems incorrect because different size corresponds to levels of `class` variable. Is color mapping also used in this legend?