### PR TITLE
fixing typos in functions.qmd

### DIFF
--- a/functions.qmd
+++ b/functions.qmd
@@ -147,11 +147,11 @@ df |> mutate(
 )
 ```
 
-(In @sec-iteration, you'll learn how to use `across()` to reduce the duplication even further so all you need is `df |> mutate(across(a:d, rescale))`).
+(In @sec-iteration, you'll learn how to use `across()` to reduce the duplication even further so all you need is `df |> mutate(across(a:d, rescale01))`).
 
 ### Improving our function
 
-You might notice `rescale()` function does some unnecessary work --- instead of computing `min()` twice and `max()` once we could instead compute both the minimum and maximum in one step with `range()`:
+You might notice `rescale01()` function does some unnecessary work --- instead of computing `min()` twice and `max()` once we could instead compute both the minimum and maximum in one step with `range()`:
 
 ```{r}
 rescale01 <- function(x) {
@@ -193,7 +193,7 @@ z_score <- function(x) {
 }
 ```
 
-Or maybe you want to wrap up a straightforward `case_when()` in order to give it a useful.
+Or maybe you want to wrap up a straightforward `case_when()` in order to give it a useful name.
 For example, this `clamp()` function ensures all values of a vector lie in between a minimum or a maximum:
 
 ```{r}
@@ -303,7 +303,7 @@ cv(runif(100, min = 0, max = 50))
 cv(runif(100, min = 0, max = 500))
 ```
 
-Or maybe you just want to make a common pattern easier to remember by given it a memorable name:
+Or maybe you just want to make a common pattern easier to remember by giving it a memorable name:
 
 ```{r}
 # https://twitter.com/gbganalyst/status/1571619641390252033
@@ -330,7 +330,7 @@ Once you start writing functions, there are two RStudio shortcuts that are super
 -   To find the definition of a function that you've written, place the cursor on the name of the function and press `F2`.
 
 -   To quickly jump to a function, press `Ctrl + .` to open the fuzzy file and function finder and type the first few letters of your function name.
-    You can also navigate to files, Quarto sections, and more, making it a very hand navigation tool.
+    You can also navigate to files, Quarto sections, and more, making it a very handy navigation tool.
 :::
 
 ### Exercises
@@ -423,11 +423,11 @@ This is a problem of indirection, and it arises because dplyr uses **tidy evalua
 
 Tidy evaluation is great 95% of the time because it makes your data analyses very concise as you never have to say which data frame a variable comes from; it's obvious from the context.
 The downside of tidy evaluation comes when we want to wrap up repeated tidyverse code into a function.
-Here we need some way tell `distinct()` and `pull()` not to treat `var` as the name of a variable, but instead look inside `var` for the variable we actually want to use.
+Here we need some way to tell `distinct()` and `pull()` not to treat `var` as the name of a variable, but instead look inside `var` for the variable we actually want to use.
 
 Tidy evaluation includes a solution to this problem called **embracing**.
 Embracing a variable means to wrap it in braces so (e.g.) `var` becomes `{{ var }}`.
-Embracing a variable tells dplyr to use the value stored inside the argument, not the argument as the a literal variable name.
+Embracing a variable tells dplyr to use the value stored inside the argument, not the argument as the literal variable name.
 One way to remember what's happening is to think of `{{ }}` as looking down a tunnel --- `{{ var }}` will make a dplyr function look inside of `var` rather than looking for a variable called `var`.
 
 So to make `pull_unique()` work we need to replace `var` with `{{ var }}`:
@@ -495,7 +495,7 @@ diamonds |>
   summary6(log10(carat))
 ```
 
-To summarize multiple variables you'll need wait until @sec-across, where you'll learn how to use `across()`.
+To summarize multiple variables you'll need to wait until @sec-across, where you'll learn how to use `across()`.
 
 Another popular `summarise()` helper function is a version of `count()` that also computes proportions:
 
@@ -512,7 +512,7 @@ diamonds |> count_prop(clarity)
 This function has three arguments: `df`, `var`, and `sort`, and only `var` needs to be embraced because it's passed to `count()` which uses data-masking for all variables in `…`.
 
 Or maybe you want to find the sorted unique values of a variable for a subset of the data.
-Rather than supplying a variable and a value to do the filtering, we'll allow the user to supply an condition:
+Rather than supplying a variable and a value to do the filtering, we'll allow the user to supply a condition:
 
 ```{r}
 unique_where <- function(df, condition, var) {


### PR DESCRIPTION
In addition to these, there is also inconsistent use of `summarise` and `summarize`, but maybe this is on purpose to show that there are 2 spelling options?