### PR TITLE
fix typo

### DIFF
--- a/functions.qmd
+++ b/functions.qmd
@@ -595,7 +595,7 @@ While our examples have mostly focused on dplyr, tidy evaluation also underpins 
 
 ### Exercises
 
-1.  Using the datasets from nyclights13, write functions that:
+1.  Using the datasets from nycflights13, write functions that:
 
     1.  Find all flights that were cancelled (i.e. `is.na(arr_time)`) or delayed by more than an hour.
 


### PR DESCRIPTION
It fixes a typo by changing `nyclights13` to `nycflights13`.