### PR TITLE
ggsave's first attribute is filename, not path

### DIFF
--- a/functions.qmd
+++ b/functions.qmd
@@ -798,7 +798,7 @@ foo(cyl)
 ```
 
 As with data frame functions, it can be useful to make your plotting functions tightly coupled to a specific dataset, or even a specific variable.
-For example, the following function makes it particularly easy to interactively explore the conditional distribution `bill_length_mm` from palmerpenguins dataset.
+For example, the following function makes it particularly easy to interactively explore the conditional distribution of `carats` from the diamonds dataset.
 
 ```{r}
 # https://twitter.com/yutannihilat_en/status/1574387230025875457

--- a/iteration.qmd
+++ b/iteration.qmd
@@ -978,7 +978,7 @@ carat_histogram <- function(df) {
 carat_histogram(by_clarity$data[[1]])
 ```
 
-Now we can use `map()` to create a list of many plots[^iteration-6] and their eventual file paths:
+Now we can use `map()` to create a list of many plots[^iteration-6] and their eventual file names:
 
 [^iteration-6]: You can print `by_clarity$plot` to get a crude animation --- you'll get one plot for each element of `plots`.
     NOTE: this didn't happen for me.
@@ -987,7 +987,7 @@ Now we can use `map()` to create a list of many plots[^iteration-6] and their ev
 by_clarity <- by_clarity |> 
   mutate(
     plot = map(data, carat_histogram),
-    path = str_glue("clarity-{clarity}.png")
+    filename = str_glue("clarity-{clarity}.png")
   )
 ```
 
@@ -995,9 +995,9 @@ Then use `walk2()` with `ggsave()` to save each plot:
 
 ```{r}
 walk2(
-  by_clarity$path,
+  by_clarity$filename,
   by_clarity$plot,
-  \(path, plot) ggsave(path, plot, width = 6, height = 6)
+  \(filename, plot) ggsave(filename, plot, width = 6, height = 6)
 )
 ```
 
@@ -1005,16 +1005,16 @@ This is shorthand for:
 
 ```{r}
 #| eval: false
-ggsave(by_clarity$path[[1]], by_clarity$plot[[1]], width = 6, height = 6)
-ggsave(by_clarity$path[[2]], by_clarity$plot[[2]], width = 6, height = 6)
-ggsave(by_clarity$path[[3]], by_clarity$plot[[3]], width = 6, height = 6)
+ggsave(by_clarity$filename[[1]], by_clarity$plot[[1]], width = 6, height = 6)
+ggsave(by_clarity$filename[[2]], by_clarity$plot[[2]], width = 6, height = 6)
+ggsave(by_clarity$filename[[3]], by_clarity$plot[[3]], width = 6, height = 6)
 ...
-ggsave(by_clarity$path[[8]], by_clarity$plot[[8]], width = 6, height = 6)
+ggsave(by_clarity$filename[[8]], by_clarity$plot[[8]], width = 6, height = 6)
 ```
 
 ```{r}
 #| include: false
-unlink(by_clarity$path)
+unlink(by_clarity$filename)
 ```
 
 ```{=html}


### PR DESCRIPTION
I think it's potentially somewhat misleading to use for ggsave "path" instead of "filename" in the example below.  I might be wrong, but I think what happens in the proposed

` ggsave(path, plot, width = 6, height = 6)`

is actually 

`ggsave(filename=path, path=NULL, plot=plot, width=6, height=6). `

It might be clearer for the reader, to use filename instead of path:

`ggsave(filename=filename, plot=plot, width=6, height=6)`

At least I found it somewhat confusing when reading the text. But feel free to ignore.
