### PR TITLE
Fix typo

### DIFF
--- a/functions.qmd
+++ b/functions.qmd
@@ -618,7 +618,7 @@ While our examples have mostly focused on dplyr, tidy evaluation also underpins 
         flights |> filter_severe(hours = 2)
         ```
 
-    4.  Summarizes the weather to compute the minum, mean, and maximum, of a user supplied variable:
+    4.  Summarizes the weather to compute the minimum, mean, and maximum, of a user supplied variable:
 
         ```{r}
         #| eval: false


### PR DESCRIPTION
It fixes a minor typo by changing `minum` to `minimum`.