### PR TITLE
Fix typo

### DIFF
--- a/functions.qmd
+++ b/functions.qmd
@@ -804,7 +804,7 @@ foo(cyl)
 ```
 
 As with data frame functions, it can be useful to make your plotting functions tightly coupled to a specific dataset, or even a specific variable.
-For example, the following function makes it particularly easy to interactively explore the conditional distribution of `carats` from the diamonds dataset.
+For example, the following function makes it particularly easy to interactively explore the conditional distribution of `carat` from the diamonds dataset.
 
 ```{r}
 # https://twitter.com/yutannihilat_en/status/1574387230025875457


### PR DESCRIPTION
It fixes a variable name from the **diamonds** dataset by changing `carats` to `carat`.