### PR TITLE
Text insertion and arguments update/alignment

### DIFF
--- a/EDA.qmd
+++ b/EDA.qmd
@@ -376,7 +376,7 @@ For example, let's explore how the price of a diamond varies with its quality (m
 #|   Ideal diamonds have the highest peak around 1500.
 
 ggplot(diamonds, aes(x = price)) + 
-  geom_freqpoly(aes(color = cut), binwidth = 500, size = 0.75)
+  geom_freqpoly(aes(color = cut), binwidth = 500, linewidth = 0.75)
 ```
 
 The default appearance of `geom_freqpoly()` is not that useful for that sort of comparison because the height is given by the count and the overall counts of `cut` in differ so much, making it hard to see the differences in the shapes of their distributions:
@@ -404,7 +404,7 @@ Instead of displaying count, we'll display the **density**, which is the count s
 #|   around a price of 1500 and Fair diamonds have a higher mean than others.
 
 ggplot(diamonds, aes(x = price, y = after_stat(density))) + 
-  geom_freqpoly(aes(color = cut), binwidth = 500, size = 0.75)
+  geom_freqpoly(aes(color = cut), binwidth = 500, linewidth = 0.75)
 ```
 
 Note that we're mapping the density the `y`, but since `density` is not a variable in the `diamonds` dataset, we need to first calculate it.

--- a/communication.qmd
+++ b/communication.qmd
@@ -841,7 +841,7 @@ mpg |>
 
 You can also set the `limits` on individual scales.
 Reducing the limits is basically equivalent to subsetting the data.
-It is generally more useful if you want *expand* the limits, for example, to match scales across different plots.
+It is generally more useful if you want to *expand* the limits, for example, to match scales across different plots.
 For example, if we extract two classes of cars and plot them separately, it's difficult to compare the plots because all three scales (the x-axis, the y-axis, and the color aesthetic) have different ranges.
 
 ```{r}
@@ -1098,7 +1098,7 @@ p5 <- ggplot(mpg, aes(x = cty, y = hwy, color = drv)) +
     guides = "collect",
     heights = c(1, 3, 2, 4)
     ) &
-  theme(legend.position = "bottom")
+  theme(legend.position = "top")
 ```
 
 If you'd like to learn more about combining and layout out multiple plots with patchwork, we recommend looking through the guides on the package website: <https://patchwork.data-imaginist.com>.


### PR DESCRIPTION
In EDA, line 379, ggplot2 prints a warning that the `size` argument has been deprecated and should be replaced with `linewidth`. I did the same replacement in line 407.

In communication, I added "to" in line 844 to read "It is generally more useful if you want to *expand* the limits..."

In line 1101, I changed the legend.position argument to "top" to align with what was written in line 1053.