### PR TITLE
Update old function name

### DIFF
--- a/iteration.qmd
+++ b/iteration.qmd
@@ -881,7 +881,7 @@ append_file <- function(path) {
 }
 ```
 
-Now we need to call `append_csv()` once for each element of `paths`.
+Now we need to call `append_file()` once for each element of `paths`.
 That's certainly possible with `map()`:
 
 ```{r}


### PR DESCRIPTION
The function `append_csv()` is nowhere to be found the rest of the book. I assume from the context that `append_csv` is an earlier name of what is now `append_file`