### PR TITLE
Fix vs. e.g. i.e. punctuation

### DIFF
--- a/data-import.qmd
+++ b/data-import.qmd
@@ -262,7 +262,7 @@ Once you've mastered `read_csv()`, using readr's other functions is straightforw
 
 ## Controlling column types {#sec-col-types}
 
-A CSV file doesn't contain any information about the type of each variable (i.e., whether it's a logical, number, string, etc.), so readr will try to guess the type.
+A CSV file doesn't contain any information about the type of each variable (i.e. whether it's a logical, number, string, etc.), so readr will try to guess the type.
 This section describes how the guessing process works, how to resolve some common problems that cause it to fail, and, if needed, how to supply the column types yourself.
 Finally, we'll mention a few general strategies that are useful if readr is failing catastrophically and you need to get more insight into the structure of your file.
 

--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -365,7 +365,7 @@ We finally have a plot that perfectly matches our "ultimate goal"!
 3.  Make a scatterplot of `bill_depth_mm` vs. `bill_length_mm`.
     Describe the relationship between these two variables.
 
-4.  What happens if you make a scatterplot of `species` vs `bill_depth_mm`?
+4.  What happens if you make a scatterplot of `species` vs. `bill_depth_mm`?
     Why is the plot not useful?
 
 5.  Why does the following give an error and how would you fix it?

--- a/numbers.qmd
+++ b/numbers.qmd
@@ -548,7 +548,7 @@ events
 ```
 
 But how do we go from that logical vector to something that we can `group_by()`?
-`cumsum()` from @sec-cumulative-and-rolling-aggregates comes to the rescue as each occurring gap, i.e., `gap` is `TRUE`, increments `group` by one (see @sec-numeric-summaries-of-logicals on the numerical interpretation of logicals):
+`cumsum()` from @sec-cumulative-and-rolling-aggregates comes to the rescue as each occurring gap, i.e. `gap` is `TRUE`, increments `group` by one (see @sec-numeric-summaries-of-logicals on the numerical interpretation of logicals):
 
 ```{r}
 events |> mutate(

--- a/quarto-formats.qmd
+++ b/quarto-formats.qmd
@@ -41,7 +41,7 @@ There are two ways to set the output of a document:
 
 Quarto offers a wide range of output formats.
 You can find the complete list at <https://quarto.org/docs/output-formats/all-formats.html>.
-Many formats share some output options (e.g., `toc: true` for including a table of contents), but others have options that are format specific (e.g., `code-fold: true` collapses code chunks into a `<details>` tag for HTML output so the user can display it on demand, it's not applicable in a PDF or Word document).
+Many formats share some output options (e.g. `toc: true` for including a table of contents), but others have options that are format specific (e.g. `code-fold: true` collapses code chunks into a `<details>` tag for HTML output so the user can display it on demand, it's not applicable in a PDF or Word document).
 
 To override the default options, you need to use an expanded `format` field.
 For example, if you wanted to render an `html` with a floating table of contents, you'd use:

--- a/regexps.qmd
+++ b/regexps.qmd
@@ -73,9 +73,9 @@ str_view(fruit, "a...e")
 
 **Quantifiers** control how many times a pattern can match:
 
--   `?` makes a pattern optional (i.e., it matches 0 or 1 times)
--   `+` lets a pattern repeat (i.e., it matches at least once)
--   `*` lets a pattern be optional or repeat (i.e., it matches any number of times, including 0).
+-   `?` makes a pattern optional (i.e. it matches 0 or 1 times)
+-   `+` lets a pattern repeat (i.e. it matches at least once)
+-   `*` lets a pattern be optional or repeat (i.e. it matches any number of times, including 0).
 
 ```{r}
 # ab? matches an "a", optionally followed by a "b".

--- a/spreadsheets.qmd
+++ b/spreadsheets.qmd
@@ -10,7 +10,7 @@ status("complete")
 
 ## Introduction
 
-So far, you have learned about importing data from plain text files, e.g., `.csv` and `.tsv` files.
+So far, you have learned about importing data from plain text files, e.g. `.csv` and `.tsv` files.
 Sometimes you need to analyze data that lives in a spreadsheet.
 This chapter will introduce you to tools for working with data in Excel spreadsheets and Google Sheets.
 This will build on much of what you've learned in @sec-data-import, but we will also discuss additional considerations and complexities when working with data from spreadsheets.

--- a/strings.qmd
+++ b/strings.qmd
@@ -111,7 +111,7 @@ str_view(tricky)
 ```
 
 A raw string usually starts with `r"(` and finishes with `)"`.
-But if your string contains `)"` you can instead use `r"[]"` or `r"{}"`, and if that's still not enough, you can insert any number of dashes to make the opening and closing pairs unique, e.g., `` `r"--()--" ``, `` `r"---()---" ``, etc. Raw strings are flexible enough to handle any text.
+But if your string contains `)"` you can instead use `r"[]"` or `r"{}"`, and if that's still not enough, you can insert any number of dashes to make the opening and closing pairs unique, e.g. `` `r"--()--" ``, `` `r"---()---" ``, etc. Raw strings are flexible enough to handle any text.
 
 ### Other special characters
 
@@ -204,7 +204,7 @@ df |> mutate(greeting = str_glue("{{Hi {name}!}}"))
 ### `str_flatten()`
 
 `str_c()` and `glue()` work well with `mutate()` because their output is the same length as their inputs.
-What if you want a function that works well with `summarize()`, i.e., something that always returns a single string?
+What if you want a function that works well with `summarize()`, i.e. something that always returns a single string?
 That's the job of `str_flatten()`[^strings-4]: it takes a character vector and combines each element of the vector into a single string:
 
 [^strings-4]: The base R equivalent is `paste()` used with the `collapse` argument.
@@ -598,7 +598,7 @@ If you'd like to learn more, we recommend reading the detailed explanation at <h
 
 ### Letter variations
 
-Working in languages with accents poses a significant challenge when determining the position of letters (e.g., with `str_length()` and `str_sub()`) as accented letters might be encoded as a single individual character (e.g., ü) or as two characters by combining an unaccented letter (e.g., u) with a diacritic mark (e.g., ¨).
+Working in languages with accents poses a significant challenge when determining the position of letters (e.g. with `str_length()` and `str_sub()`) as accented letters might be encoded as a single individual character (e.g. ü) or as two characters by combining an unaccented letter (e.g. u) with a diacritic mark (e.g. ¨).
 For example, this code shows two ways of representing ü that look identical:
 
 ```{r}

--- a/workflow-help.qmd
+++ b/workflow-help.qmd
@@ -31,7 +31,7 @@ A good reprex makes it easier for other people to help you, and often you'll fig
 There are two parts to creating a reprex:
 
 -   First, you need to make your code reproducible.
-    This means that you need to capture everything, i.e., include any `library()` calls and create all necessary objects.
+    This means that you need to capture everything, i.e. include any `library()` calls and create all necessary objects.
     The easiest way to make sure you've done this is using the reprex package.
 
 -   Second, you need to make it minimal.

--- a/workflow-pipes.qmd
+++ b/workflow-pipes.qmd
@@ -130,7 +130,7 @@ But they're still good to know about even if you've never used `%>%` because you
 
 Luckily there's no need to commit entirely to one pipe or the other --- you can use the base pipe for the majority of cases where it's sufficient and use the magrittr pipe when you really need its special features.
 
-## `|>` vs `+`
+## `|>` vs. `+`
 
 Sometimes we'll turn the end of a data transformation pipeline into a plot.
 Watch for the transition from `|>` to `+`.


### PR DESCRIPTION
The purpose of this pull request is identical to my past pull request #1157 which already closed the issue #1147.

It fixes punctuations where we have
- missing `.` after `vs`
- unnecessary `,` after `e.g.` or `i.e.`