### PR TITLE
changed and to or, which is the technically true description I believe

### DIFF
--- a/data-visualize.qmd
+++ b/data-visualize.qmd
@@ -207,7 +207,7 @@ Before we add more layers to this plot, let's pause for a moment and review the 
 
 > Removed 2 rows containing missing values (`geom_point()`).
 
-We're seeing this message because there are two penguins in our dataset with missing body mass and flipper length values and ggplot2 has no way of representing them on the plot.
+We're seeing this message because there are two penguins in our dataset with missing body mass or flipper length values and ggplot2 has no way of representing them on the plot.
 You don't need to worry about understanding the following code yet (you will learn about it in @sec-data-transform), but it's one way of identifying the observations with `NA`s for either body mass or flipper length.
 
 ```{r}


### PR DESCRIPTION
not super important but technically and should be or. It turns out that both variables have NAs but the same error would pop up even if only one was missing. Also or doesn't exclude "both". 