### PR TITLE
Typo Correction in Section 11.3

### DIFF
--- a/layers.qmd
+++ b/layers.qmd
@@ -362,7 +362,7 @@ ggplot(mpg, aes(x = displ, y = hwy)) +
 
 You can use the same idea to specify different `data` for each layer.
 Here, we use red points as well as open circles to highlight two-seater cars.
-The local data argument in `geom_smooth()` overrides the global data argument in `ggplot()` for that layer only.
+The local data argument in `geom_point()` overrides the global data argument in `ggplot()` for that layer only.
 
 ```{r}
 #| message: false


### PR DESCRIPTION
Changed geom_smooth() to geom_point() to maintain consistency with geometric object function name in the code block below.