### PR TITLE
Fixed typos

### DIFF
--- a/layers.qmd
+++ b/layers.qmd
@@ -397,7 +397,7 @@ For example, the histogram and density plot below reveal that the distribution o
 #|   Three plots: histogram, density plot, and box plot of highway
 #|   mileage.
  
-# Left
+# Top
 ggplot(mpg, aes(x = hwy)) +
   geom_histogram(binwidth = 2)
 
@@ -405,7 +405,7 @@ ggplot(mpg, aes(x = hwy)) +
 ggplot(mpg, aes(x = hwy)) +
   geom_density()
 
-# Right
+# Bottom
 ggplot(mpg, aes(x = hwy)) +
   geom_boxplot()
 ```


### PR DESCRIPTION
Fixed typos in figure explanation : top/middle/bottom rather than left/middle/right, due to the display of figures in the text.