### PR TITLE
Fixed typos

### DIFF
--- a/EDA.qmd
+++ b/EDA.qmd
@@ -279,7 +279,7 @@ If you've encountered unusual values in your dataset, and simply want to move on
     ```
 
     We don't recommend this option because just because one measurement is invalid, doesn't mean all the measurements are.
-    Additionally, if you have low quality data, by time that you've applied this approach to every variable you might find that you don't have any data left!
+    Additionally, if you have low quality data, by the time that you've applied this approach to every variable you might find that you don't have any data left!
 
 2.  Instead, we recommend replacing the unusual values with missing values.
     The easiest way to do this is to use `mutate()` to replace the variable with a modified copy.
@@ -766,4 +766,4 @@ In this chapter you've learned a variety of tools to help you understand the var
 You've seen technique that work with a single variable at a time and with a pair of variables.
 This might seem painful restrictive if you have tens or hundreds of variables in your data, but they're foundation upon which all other techniques are built.
 
-In the next chapter, we'll tackle our final piece of workflow advice: how to get help when you're stuck.
+In the next chapter, we'll focus on the tools we can use to communicate our results.


### PR DESCRIPTION
- by time -> by the time
- last sentence of the chapter refers to next chapter as focusing on getting help, which seems to be an error due to the reordering to chapters.