### PR TITLE
Mynor typo

### DIFF
--- a/workflow-basics.qmd
+++ b/workflow-basics.qmd
@@ -173,7 +173,7 @@ If you want more help, press F1 to get all the details in the help tab in the lo
 When you've selected the function you want, press TAB again.
 RStudio will add matching opening (`(`) and closing (`)`) parentheses for you.
 Type the name of the first argument, `from`, and set it equal to `1`.
-Then, type the name of the second argument, `to`, and set it equal to `2`.
+Then, type the name of the second argument, `to`, and set it equal to `10`.
 Finally, hit return.
 
 ```{r}


### PR DESCRIPTION
Changing 2 with 10 so in the line.
"Then, type the name of the second argument, `to`, and set it equal to `10`" so it is relate to example:
```
seq(from = 1, to = 10)
```