### PR TITLE
Wrong dataset fix

### DIFF
--- a/functions.qmd
+++ b/functions.qmd
@@ -611,7 +611,7 @@ While our examples have mostly focused on dplyr, tidy evaluation also underpins 
 
         ```{r}
         #| eval: false
-        weather |> standardize_time(sched_dep_time)
+        flights |> standardize_time(sched_dep_time)
         ```
 
 2.  For each of the following functions list all arguments that use tidy evaluation and describe whether they use data-masking or tidy-selection: `distinct()`, `count()`, `group_by()`, `rename_with()`, `slice_min()`, `slice_sample()`.


### PR DESCRIPTION
This exercise asks to create a decimal time out of clock time from the `sched_dep_time` variable. However, it is calling this on the `weather` dataset, where it should be the `flights` one. Otherwise, the user will get an error.