### PR TITLE
Including msising word

### DIFF
--- a/iteration.qmd
+++ b/iteration.qmd
@@ -118,7 +118,7 @@ In simple cases, as above, this will be a single existing function.
 This is a pretty special feature of R: we're passing one function (`median`, `mean`, `str_flatten`, ...) to another function (`across`).
 This is one of the features that makes R a functional programming language.
 
-It's important to note that we're passing this function to `across()`, so `across()` can call it; we're calling it ourselves.
+It's important to note that we're passing this function to `across()`, so `across()` can call it; we're not calling it ourselves.
 That means the function name should never be followed by `()`.
 If you forget, you'll get an error:
 


### PR DESCRIPTION
I am not completely sure about this one, but I guess the real intention was saying that when you use `across` you are **not** calling the new function yourself.