### PR TITLE
Fix/workflow-basics

### DIFF
--- a/workflow-basics.qmd
+++ b/workflow-basics.qmd
@@ -180,7 +180,7 @@ Finally, hit return.
 seq(from = 1, to = 10)
 ```
 
-We often omit the names of the first arguments in function calls, so we can rewrite this as follows:
+We often omit the names of the first several arguments whose order is unambiguous in function calls, so we can rewrite this as follows:
 
 ```{r}
 seq(1, 10)

--- a/workflow-basics.qmd
+++ b/workflow-basics.qmd
@@ -180,7 +180,7 @@ Finally, hit return.
 seq(from = 1, to = 10)
 ```
 
-We often omit the names of the first several arguments whose order is unambiguous in function calls, so we can rewrite this as follows:
+We often omit the names of the first several arguments in function calls, so we can rewrite this as follows:
 
 ```{r}
 seq(1, 10)


### PR DESCRIPTION
justify omitting the name of the second argument