### PR TITLE
Fix curl::multi_download typo in arrow.qmd

### DIFF
--- a/arrow.qmd
+++ b/arrow.qmd
@@ -54,7 +54,7 @@ This dataset contains 41,389,465 rows that tell you how many times each book was
 
 The following code will get you a cached copy of the data.
 The data is a 9GB CSV file, so it will take some time to download.
-I highly recommend using `curl::multidownload()` to get very large files as it's built for exactly this purpose: it gives you a progress bar and it can resume the download if its interrupted.
+I highly recommend using `curl::multi_download()` to get very large files as it's built for exactly this purpose: it gives you a progress bar and it can resume the download if its interrupted.
 
 ```{r}
 #| eval: false


### PR DESCRIPTION
Function has an underscore in the name (as used in following code box)