### PR TITLE
Eliminate infeasible step in exercise in Ch 20

### DIFF
--- a/joins.qmd
+++ b/joins.qmd
@@ -367,8 +367,7 @@ flights2 |>
 4.  What do the tail numbers that don't have a matching record in `planes` have in common?
     (Hint: one variable explains \~90% of the problems.)
 
-5.  Add a column to `planes` that lists every `carrier` that has flown that plane.
-    You might expect that there's an implicit relationship between plane and airline, because each plane is flown by a single airline.
+5.  You might expect that there's an implicit relationship between plane and airline, because each plane is flown by a single airline.
     Confirm or reject this hypothesis using the tools you've learned in previous chapters.
 
 6.  Add the latitude and the longitude of the origin *and* destination airport to `flights`.


### PR DESCRIPTION
The first sentence in exercise 20.3.4 #5 seems to be infeasible with the tools that have been taught in the textbook.

@rntucker proposed this solution which is correct, but relies on tools not in the textbook. 
```
plane_carriers <- nycflights13::planes |>
  left_join(flights |> select(tailnum, carrier), by = "tailnum") |>
  distinct(carrier, tailnum) |>
  group_by(tailnum) |>
  summarise(all_carriers = toString(carrier), .groups = "drop") 

plane_carriers %>% count(all_carriers)
```

I suggest reverting to the language from [1e](https://r4ds.had.co.nz/relational-data.html) in which case this much simpler solution works
```
flights |>
  distinct(carrier, tailnum) |>
  count(tailnum) |>
  filter(n > 1)
```
