### PR TITLE
Bold current chapter and section

### DIFF
--- a/r4ds.scss
+++ b/r4ds.scss
@@ -8,6 +8,14 @@ $primary: #637238 !default;
   color: #637238;
 }
 
+div.sidebar-item-container .active {
+  font-weight: bold;
+}
+
+.sidebar nav[role=doc-toc] ul>li>a.active, .sidebar nav[role=doc-toc] ul>li>ul>li>a.active{
+  font-weight: bold;
+}
+
 img.quarto-cover-image {
   box-shadow: 0 .5rem 1rem rgba(0,0,0,.15);
 }


### PR DESCRIPTION
Add styling to bold the current chapter and section (instead of changing the color), e.g.,

<img width="1154" alt="Screenshot 2023-05-10 at 11 16 07 PM" src="https://github.com/hadley/r4ds/assets/5965649/fda0fe12-cd5e-4ab1-b1b4-974213db9cae">

Closes #1444.