### PR TITLE
Suggest/spreadsheet: 21.3 Google Sheets, make gs4_deauth() explicit

### DIFF
--- a/spreadsheets.qmd
+++ b/spreadsheets.qmd
@@ -630,7 +630,7 @@ write_sheet(bake_sale, ss = "bake-sale", sheet = "Sales")
 
 While you can read from a public Google Sheet without authenticating with your Google account and with `gs4_deauth()`, reading a private sheet or writing to a sheet requires authentication so that googlesheets4 can view and manage *your* Google Sheets.
 
-When you attempt to get authentication with `gs4_auth()`, googlesheets4 will direct you to a web browser with a prompt to sign in to your Google account and grant permission to operate on your behalf with Google Sheets.
+When you attempt to read in a sheet that requires authentication, googlesheets4 will direct you to a web browser with a prompt to sign in to your Google account and grant permission to operate on your behalf with Google Sheets.
 However, if you want to specify a specific Google account, authentication scope, etc. you can do so, e.g., with `gs4_auth(email = "mine@example.com")`, which will force the use of a token associated with a specific email.
 For further authentication details, we recommend reading the documentation googlesheets4 auth vignette: <https://googlesheets4.tidyverse.org/articles/auth.html>.
 

--- a/spreadsheets.qmd
+++ b/spreadsheets.qmd
@@ -631,7 +631,7 @@ write_sheet(bake_sale, ss = "bake-sale", sheet = "Sales")
 While you can read from a public Google Sheet without authenticating with your Google account and with `gs4_deauth()`, reading a private sheet or writing to a sheet requires authentication so that googlesheets4 can view and manage *your* Google Sheets.
 
 When you attempt to read in a sheet that requires authentication, googlesheets4 will direct you to a web browser with a prompt to sign in to your Google account and grant permission to operate on your behalf with Google Sheets.
-However, if you want to specify a specific Google account, authentication scope, etc. you can do so with `gs4_auth()`, e.g., with `gs4_auth(email = "mine@example.com")`, which will force the use of a token associated with a specific email.
+However, if you want to specify a specific Google account, authentication scope, etc. you can do so with `gs4_auth()`, e.g., `gs4_auth(email = "mine@example.com")`, which will force the use of a token associated with a specific email.
 For further authentication details, we recommend reading the documentation googlesheets4 auth vignette: <https://googlesheets4.tidyverse.org/articles/auth.html>.
 
 ### Exercises

--- a/spreadsheets.qmd
+++ b/spreadsheets.qmd
@@ -628,7 +628,7 @@ write_sheet(bake_sale, ss = "bake-sale", sheet = "Sales")
 
 ### Authentication
 
-While you can read from a public Google Sheet with `gs4_deauth()`: without authenticating with your Google account, reading a private sheet or writing to a sheet requires authentication so that googlesheets4 can view and manage *your* Google Sheets.
+While you can read from a public Google Sheet without authenticating with your Google account and with `gs4_deauth()`, reading a private sheet or writing to a sheet requires authentication so that googlesheets4 can view and manage *your* Google Sheets.
 
 When you attempt to get authentication with `gs4_auth()`, googlesheets4 will direct you to a web browser with a prompt to sign in to your Google account and grant permission to operate on your behalf with Google Sheets.
 However, if you want to specify a specific Google account, authentication scope, etc. you can do so, e.g., with `gs4_auth(email = "mine@example.com")`, which will force the use of a token associated with a specific email.

--- a/spreadsheets.qmd
+++ b/spreadsheets.qmd
@@ -558,8 +558,6 @@ The first argument to `read_sheet()` is the URL of the file to read, and it retu
 These URLs are not pleasant to work with, so you'll often want to identify a sheet by its ID.
 
 ```{r}
-#| include: false
-
 gs4_deauth()
 ```
 
@@ -630,10 +628,10 @@ write_sheet(bake_sale, ss = "bake-sale", sheet = "Sales")
 
 ### Authentication
 
-While you can read from a public Google Sheet without authenticating with your Google account, reading a private sheet or writing to a sheet requires authentication so that googlesheets4 can view and manage *your* Google Sheets.
+While you can read from a public Google Sheet with `gs4_deauth()`: without authenticating with your Google account, reading a private sheet or writing to a sheet requires authentication so that googlesheets4 can view and manage *your* Google Sheets.
 
-When you attempt to read in a sheet that requires authentication, googlesheets4 will direct you to a web browser with a prompt to sign in to your Google account and grant permission to operate on your behalf with Google Sheets.
-However, if you want to specify a specific Google account, authentication scope, etc. you can do so with `gs4_auth()`, e.g., `gs4_auth(email = "mine@example.com")`, which will force the use of a token associated with a specific email.
+When you attempt to get authentication with `gs4_auth()`, googlesheets4 will direct you to a web browser with a prompt to sign in to your Google account and grant permission to operate on your behalf with Google Sheets.
+However, if you want to specify a specific Google account, authentication scope, etc. you can do so, e.g., with `gs4_auth(email = "mine@example.com")`, which will force the use of a token associated with a specific email.
 For further authentication details, we recommend reading the documentation googlesheets4 auth vignette: <https://googlesheets4.tidyverse.org/articles/auth.html>.
 
 ### Exercises

--- a/spreadsheets.qmd
+++ b/spreadsheets.qmd
@@ -631,7 +631,7 @@ write_sheet(bake_sale, ss = "bake-sale", sheet = "Sales")
 While you can read from a public Google Sheet without authenticating with your Google account and with `gs4_deauth()`, reading a private sheet or writing to a sheet requires authentication so that googlesheets4 can view and manage *your* Google Sheets.
 
 When you attempt to read in a sheet that requires authentication, googlesheets4 will direct you to a web browser with a prompt to sign in to your Google account and grant permission to operate on your behalf with Google Sheets.
-However, if you want to specify a specific Google account, authentication scope, etc. you can do so, e.g., with `gs4_auth(email = "mine@example.com")`, which will force the use of a token associated with a specific email.
+However, if you want to specify a specific Google account, authentication scope, etc. you can do so with `gs4_auth()`, e.g., with `gs4_auth(email = "mine@example.com")`, which will force the use of a token associated with a specific email.
 For further authentication details, we recommend reading the documentation googlesheets4 auth vignette: <https://googlesheets4.tidyverse.org/articles/auth.html>.
 
 ### Exercises


### PR DESCRIPTION
I failed to read_sheet() until I found gs4_deauth() was executed before read_sheet().
I suggest it is better to show gs4_deauth() instead of hiding it by setting include = false.
I also would like to suggest some changes in Authentication section accordingly.