### PR TITLE
Update data-transform.qmd, fixed sentence

### DIFF
--- a/data-transform.qmd
+++ b/data-transform.qmd
@@ -727,7 +727,7 @@ flights |>
 
 `.by` works with all verbs and has the advantage that you don't need to use the `.groups` argument to suppress the grouping message or `ungroup()` when you're done.
 
-We didn't focus on this syntax in this chapter because it was very new when wrote the book.
+We didn't focus on this syntax in this chapter because it was very new when we wrote the book.
 We did want to mention it because we think it has a lot of promise and it's likely to be quite popular.
 You can learn more about it in the [dplyr 1.1.0 blog post](https://www.tidyverse.org/blog/2023/02/dplyr-1-1-0-per-operation-grouping/).
 


### PR DESCRIPTION
The original sentence read "We didn't focus on this syntax in this chapter because it was very new when wrote the book. ", and I added a missing subject, so it now reads "We didn't focus on this syntax in this chapter because it was very new when we wrote the book."