### PR TITLE
Suggest/Strings, 15.4.3 Diagnosing widening problems, double "x"

### DIFF
--- a/strings.qmd
+++ b/strings.qmd
@@ -356,7 +356,7 @@ df |>
   separate_wider_delim(
     x,
     delim = "-",
-    names = c("x", "y", "z")
+    names = c("a", "b", "c")
   )
 ```
 
@@ -368,13 +368,13 @@ debug <- df |>
   separate_wider_delim(
     x,
     delim = "-",
-    names = c("x", "y", "z"),
+    names = c("a", "b", "c"),
     too_few = "debug"
   )
 debug
 ```
 
-When you use the debug mode, you get three extra columns added to the output: `x_ok`, `x_pieces`, and `x_remainder` (if you separate a variable with a different name, you'll get a different prefix).
+When you use the debug mode, you get three extra columns added to the output and the input: `x_ok`, `x_pieces`, and `x_remainder` (if you separate a variable with a different name, you'll get a different prefix).
 Here, `x_ok` lets you quickly find the inputs that failed:
 
 ```{r}
@@ -395,7 +395,7 @@ df |>
   separate_wider_delim(
     x,
     delim = "-",
-    names = c("x", "y", "z"),
+    names = c("a", "b", "c"),
     too_few = "align_start"
   )
 ```
@@ -410,7 +410,7 @@ df |>
   separate_wider_delim(
     x,
     delim = "-",
-    names = c("x", "y", "z")
+    names = c("a", "b", "c")
   )
 ```
 
@@ -421,7 +421,7 @@ debug <- df |>
   separate_wider_delim(
     x,
     delim = "-",
-    names = c("x", "y", "z"),
+    names = c("a", "b", "c"),
     too_many = "debug"
   )
 debug |> filter(!x_ok)
@@ -434,7 +434,7 @@ df |>
   separate_wider_delim(
     x,
     delim = "-",
-    names = c("x", "y", "z"),
+    names = c("a", "b", "c"),
     too_many = "drop"
   )
 
@@ -443,7 +443,7 @@ df |>
   separate_wider_delim(
     x,
     delim = "-",
-    names = c("x", "y", "z"),
+    names = c("a", "b", "c"),
     too_many = "merge"
   )
 ```


### PR DESCRIPTION
Input column is "x" and output columns are c("x", "y", "z), so "x" is duplicated.
I would like to suggest to replace names = c("x", "y", "z) with c("a", "b", "c").