### PR TITLE
Suggest/Strings, 15.6.1 Encoding, inline CSVs don't work

### DIFF
--- a/strings.qmd
+++ b/strings.qmd
@@ -545,7 +545,7 @@ readr uses UTF-8 everywhere.
 This is a good default but will fail for data produced by older systems that don't use UTF-8.
 If this happens, your strings will look weird when you print them.
 Sometimes just one or two characters might be messed up; other times, you'll get complete gibberish.
-For example here are two inline CSVs with unusual encodings[^strings-7]:
+For example here are two CSVs with unusual encodings[^strings-7]:
 
 [^strings-7]: Here I'm using the special `\x` to encode binary data directly into a string.
 
@@ -553,11 +553,13 @@ For example here are two inline CSVs with unusual encodings[^strings-7]:
 #| eval: false
 
 x1 <- "text\nEl Ni\xf1o was particularly bad this year"
-read_csv(x1)$text
+writeLines(x1, "x1.csv")
+read_csv("x1.csv")$text
 #> [1] "El Ni\xf1o was particularly bad this year"
 
 x2 <- "text\n\x82\xb1\x82\xf1\x82\xc9\x82\xbf\x82\xcd"
-read_csv(x2)$text
+writeLines(x2, "x2.csv")
+read_csv("x2.csv")$text
 #> [1] "\x82\xb1\x82\xf1\x82ɂ\xbf\x82\xcd"
 ```
 
@@ -565,10 +567,10 @@ To read these correctly, you specify the encoding via the `locale` argument:
 
 ```{r}
 #| eval: false
-read_csv(x1, locale = locale(encoding = "Latin1"))$text
+read_csv("x1.csv", locale = locale(encoding = "Latin1"))$text
 #> [1] "El Niño was particularly bad this year"
 
-read_csv(x2, locale = locale(encoding = "Shift-JIS"))$text
+read_csv("x2.csv", locale = locale(encoding = "Shift-JIS"))$text
 #> [1] "こんにちは"
 ```
 


### PR DESCRIPTION
Inline CSVs including binary data are not recognized as CSVs in my environment (Linux).
As the following code chunks are eval = false, I would like to suggest to write x1 as a CSV file "x1.csv". 