### PR TITLE
Suggest/26 Functions, last paragraph is invalid in 2nd edition

### DIFF
--- a/functions.qmd
+++ b/functions.qmd
@@ -871,5 +871,4 @@ A few places to learn more are:
 -   To learn more about reducing duplication in your ggplot2 code, read the [Programming with ggplot2](https://ggplot2-book.org/programming.html){.uri} chapter of the ggplot2 book.
 -   For more advice on function style, see the [tidyverse style guide](https://style.tidyverse.org/functions.html){.uri}.
 
-In the next chapter, we'll dive into some of the details of R's vector data structures that we've omitted so far.
-These are not immediately useful by themselves, but are a necessary foundation for the following chapter on iteration which gives you further tools for reducing code duplication.
+In the next chapter, we'll dive into iteration which gives you further tools for reducing code duplication.


### PR DESCRIPTION
The current last paragraph of 26 Functions assumes the next chapter is Vectors and the next next chapter is Iteration, as they were in the 1st edition. However, the next chapter is Iteration in the 2nd edition.
So I would like to suggest to omit references to Vectors.