### PR TITLE
Fix/base-R typos and Figure 28.1 pepper caption

### DIFF
--- a/base-R.qmd
+++ b/base-R.qmd
@@ -349,8 +349,8 @@ If we suppose this pepper shaker is a list called `pepper`, then `pepper[1]` is 
 #| out-width: "100%"
 #| fig-cap: >
 #|   (Left) A pepper shaker that Hadley once found in his hotel room.
-#|   (Middle) `pepper[1]`.
-#|   (Right) `pepper[[1]]`
+#|   (Middle) `pepper[[1]]`.
+#|   (Right) `pepper[[1]][[1]]`
 #| fig-alt: >
 #|   Three photos. On the left is a photo of a glass pepper shaker. Instead of 
 #|   the pepper shaker containing pepper, it contains a single packet of pepper.

--- a/base-R.qmd
+++ b/base-R.qmd
@@ -443,7 +443,7 @@ for (element in vector) {
 }
 ```
 
-The most straightforward use of `for` loops is to achieve the same affect as `walk()`: call some function with a side-effect on each element of a list.
+The most straightforward use of `for` loops is to achieve the same effect as `walk()`: call some function with a side-effect on each element of a list.
 For example, in @sec-save-database instead of using walk:
 
 ```{r}

--- a/base-R.qmd
+++ b/base-R.qmd
@@ -300,7 +300,7 @@ For this reason we sometimes joke that tibbles are lazy and surly: they do less 
 ### Lists
 
 `[[` and `$` are also really important for working with lists, and it's important to understand how they differ from `[`.
-Lets illustrate the differences with a list named `l`:
+Let's illustrate the differences with a list named `l`:
 
 ```{r}
 l <- list(


### PR DESCRIPTION
I correct Figure 28.1 caption, according to 1st edition, 20.5.3 Lists of condiments.