### PR TITLE
Fix/quarto mostly typos

### DIFF
--- a/quarto.qmd
+++ b/quarto.qmd
@@ -429,7 +429,7 @@ comma(.12358124331)
 
 The figures in a Quarto document can be embedded (e.g., a PNG or JPEG file) or generated as a result of a code chunk.
 
-To embed an image from an external file, you can use the Insert menu in the visual editor in RStudio and select Figure / Image.
+To embed an image from an external file, you can use the Insert menu in the Visual Editor in RStudio and select Figure / Image.
 This will pop open a menu where you can browse to the image you want to insert as well as add alternative text or caption to it and adjust its size.
 In the visual editor you can also simply paste an image from your clipboard into your document and RStudio will place a copy of that image in your project folder.
 

--- a/quarto.qmd
+++ b/quarto.qmd
@@ -429,7 +429,7 @@ comma(.12358124331)
 
 The figures in a Quarto document can be embedded (e.g., a PNG or JPEG file) or generated as a result of a code chunk.
 
-To embed an image from an external file, you can use the Insert menu in RStudio and select Figure / Image.
+To embed an image from an external file, you can use the Insert menu in the visual editor in RStudio and select Figure / Image.
 This will pop open a menu where you can browse to the image you want to insert as well as add alternative text or caption to it and adjust its size.
 In the visual editor you can also simply paste an image from your clipboard into your document and RStudio will place a copy of that image in your project folder.
 

--- a/quarto.qmd
+++ b/quarto.qmd
@@ -515,7 +515,7 @@ The chunk label is used to generate the file name of the graphic on disk, so nam
 ### Exercises
 
 1.  Open `diamond-sizes.qmd` in the visual editor, find an image of a diamond, copy it, and paste it into the document. Double click on the image and add a caption. Resize the image and render your document. Observe how the image is saved in your current working directory.
-2.  Edit the label of the code chunk in `diamond-sizes.qmd` that generates a plot to start with the suffix `fig-` and add a caption to the figure with the chunk option `fig-cap`. Then, edit the text above the code chunk to add a cross-reference to the figure with Insert \> Cross Reference.
+2.  Edit the label of the code chunk in `diamond-sizes.qmd` that generates a plot to start with the prefix `fig-` and add a caption to the figure with the chunk option `fig-cap`. Then, edit the text above the code chunk to add a cross-reference to the figure with Insert \> Cross Reference.
 3.  Change the size of the figure with the following chunk options, one at a time, render your document, and describe how the figure changes.
     a.  `fig-width: 10`
 
@@ -555,7 +555,7 @@ Each provides a set of tools for returning formatted tables from R code.
 
 1.  Open `diamond-sizes.qmd` in the visual editor, insert a code chunk, and add a table with `knitr::kable()` that shows the first 5 rows of the `diamonds` data frame.
 2.  Display the same table with `gt::gt()` instead.
-3.  Add a chunk label that starts with the suffix `tbl-` and add a caption to the table with the chunk option `tbl-cap`. Then, edit the text above the code chunk to add a cross-reference to the table with Insert \> Cross Reference.
+3.  Add a chunk label that starts with the prefix `tbl-` and add a caption to the table with the chunk option `tbl-cap`. Then, edit the text above the code chunk to add a cross-reference to the table with Insert \> Cross Reference.
 
 ## Caching {#sec-caching}
 

--- a/quarto.qmd
+++ b/quarto.qmd
@@ -490,7 +490,7 @@ plot
 ```
 
 If you want to make sure the font size is consistent across all your figures, whenever you set `out-width`, you'll also need to adjust `fig-width` to maintain the same ratio with your default `out-width`.
-For example, if your default `fig-width` is 6 and `out-width` is 0.7, when you set `out-width: "50%"` you'll need to set `fig-width` to 4.3 (6 \* 0.5 / 0.7).
+For example, if your default `fig-width` is 6 and `out-width` is "70%", when you set `out-width: "50%"` you'll need to set `fig-width` to 4.3 (6 \* 0.5 / 0.7).
 
 Figure sizing and scaling is an art and science and getting things right can require an iterative trial-and-error approach.
 You can learn more about figure sizing in the [taking control of plot scaling blog post](https://www.tidyverse.org/blog/2020/08/taking-control-of-plot-scaling/).

--- a/quarto.qmd
+++ b/quarto.qmd
@@ -589,37 +589,33 @@ On subsequent runs, knitr will check to see if the code has changed, and if it h
 The caching system must be used with care, because by default it is based on the code only, not its dependencies.
 For example, here the `processed_data` chunk depends on the `raw-data` chunk:
 
-```         
-`r chunk`{r}
-#| label: raw-data
+    `r chunk`{r}
+    #| label: raw-data
 
-rawdata <- readr::read_csv("a_very_large_file.csv")
-`r chunk`
+    rawdata <- readr::read_csv("a_very_large_file.csv")
+    `r chunk`
 
-`r chunk`{r}
-#| label: processed_data
-#| cache: true
+    `r chunk`{r}
+    #| label: processed_data
+    #| cache: true
 
-processed_data <- rawdata |> 
-  filter(!is.na(import_var)) |> 
-  mutate(new_variable = complicated_transformation(x, y, z))
-`r chunk`
-```
+    processed_data <- rawdata |> 
+      filter(!is.na(import_var)) |> 
+      mutate(new_variable = complicated_transformation(x, y, z))
+    `r chunk`
 
 Caching the `processed_data` chunk means that it will get re-run if the dplyr pipeline is changed, but it won't get rerun if the `read_csv()` call changes.
 You can avoid that problem with the `dependson` chunk option:
 
-```         
-`r chunk`{r}
-#| label: processed-data
-#| cache: true
-#| dependson: "raw-data"
+    `r chunk`{r}
+    #| label: processed-data
+    #| cache: true
+    #| dependson: "raw-data"
 
-processed_data <- rawdata |> 
-  filter(!is.na(import_var)) |> 
-  mutate(new_variable = complicated_transformation(x, y, z))
-`r chunk`
-```
+    processed_data <- rawdata |> 
+      filter(!is.na(import_var)) |> 
+      mutate(new_variable = complicated_transformation(x, y, z))
+    `r chunk`
 
 `dependson` should contain a character vector of *every* chunk that the cached chunk depends on.
 Knitr will update the results for the cached chunk whenever it detects that one of its dependencies have changed.
@@ -630,14 +626,12 @@ This is an arbitrary R expression that will invalidate the cache whenever it cha
 A good function to use is `file.info()`: it returns a bunch of information about the file including when it was last modified.
 Then you can write:
 
-```         
-`r chunk`{r}
-#| label: raw-data
-#| cache.extra: file.info("a_very_large_file.csv")
+    `r chunk`{r}
+    #| label: raw-data
+    #| cache.extra: file.info("a_very_large_file.csv")
 
-rawdata <- readr::read_csv("a_very_large_file.csv")
-`r chunk`
-```
+    rawdata <- readr::read_csv("a_very_large_file.csv")
+    `r chunk`
 
 We've followed the advice of [David Robinson](https://twitter.com/drob/status/738786604731490304) to name these chunks: each chunk is named after the primary object that it creates.
 This makes it easier to understand the `dependson` specification.

--- a/quarto.qmd
+++ b/quarto.qmd
@@ -422,7 +422,7 @@ comma(.12358124331)
 2.  Download `diamond-sizes.qmd` from <https://github.com/hadley/r4ds/tree/main/quarto>.
     Add a section that describes the largest 20 diamonds, including a table that displays their most important attributes.
 
-3.  Modify `diamonds-sizes.qmd` to use `comma()` to produce nicely formatted output.
+3.  Modify `diamonds-sizes.qmd` to use `label_comma()` to produce nicely formatted output.
     Also include the percentage of diamonds that are larger than 2.5 carats.
 
 ## Figures {#sec-figures}

--- a/quarto.qmd
+++ b/quarto.qmd
@@ -711,13 +711,13 @@ cat(readr::read_file("quarto/fuel-economy.qmd"))
 As you can see, parameters are available within the code chunks as a read-only list named `params`.
 
 You can write atomic vectors directly into the YAML header.
-You can also run arbitrary R expressions by prefacing the parameter value with `!r`.
+You can also run arbitrary R expressions by prefacing the parameter value with `!expr`.
 This is a good way to specify date/time parameters.
 
 ``` yaml
 params:
-  start: !r lubridate::ymd("2015-01-01")
-  snapshot: !r lubridate::ymd_hms("2015-01-01 12:30:00")
+  start: !expr lubridate::ymd("2015-01-01")
+  snapshot: !expr lubridate::ymd_hms("2015-01-01 12:30:00")
 ```
 
 ### Bibliographies and Citations

--- a/quarto.qmd
+++ b/quarto.qmd
@@ -683,9 +683,6 @@ If you publish the HTML file on a hosting platform (e.g., QuartoPub, <https://qu
 However, if you want to email the report to a colleague, you might prefer to have a single, self-contained, HTML document that embeds all of its dependencies.
 You can do this by specifying the `embed-resources` option:
 
-By default these dependencies are placed in a `_files` directory alongside your document.
-For example, if you render `report.qmd` to HTML:
-
 ``` yaml
 format:
   html:

--- a/quarto.qmd
+++ b/quarto.qmd
@@ -510,7 +510,7 @@ In that case, set `fig-format: "png"` to force the use of PNGs.
 They are slightly lower quality, but will be much more compact.
 
 It's a good idea to name code chunks that produce figures, even if you don't routinely label other chunks.
-The chunk label is used to generate the file name of the graphic on disk, so naming your chunks makes it much easier to pick out plots and reuse in other circumstances (i.e. if you want to quickly drop a single plot into an email).
+The chunk label is used to generate the file name of the graphic on disk, so naming your chunks makes it much easier to pick out plots and reuse in other circumstances (e.g., if you want to quickly drop a single plot into an email).
 
 ### Exercises
 

--- a/quarto.qmd
+++ b/quarto.qmd
@@ -448,7 +448,7 @@ We recommend three of the five options:
     Then in individual chunks, only adjust `fig-asp`.
 
 -   Control the output size with `out-width` and set it to a percentage of the line width.
-    We suggest to `out-width: "70%"` and `fig-align: center`.
+    We suggest `out-width: "70%"` and `fig-align: center`.
     That gives plots room to breathe, without taking up too much space.
 
 -   To put multiple plots in a single row, set the `layout-ncol` to 2 for two plots, 3 for three plots, etc.

--- a/quarto.qmd
+++ b/quarto.qmd
@@ -837,7 +837,7 @@ We've drawn on our own experiences and Colin Purrington's advice on lab notebook
 
 ## Summary
 
-In this chapter introduced you to Quarto for authoring and publishing reproducible computational documents that include your code and your prose in one place.
+In this chapter we introduced you to Quarto for authoring and publishing reproducible computational documents that include your code and your prose in one place.
 You've learned about writing Quarto documents in RStudio with the visual or the source editor, how code chunks work and how to customize options for them, how to include figures and tables in your Quarto documents, and options for caching for computations.
 Additionally, you've learned about adjusting YAML header options for creating self-contained or parametrized documents as well as including citations and bibliography.
 We have also given you some troubleshooting and workflow tips.

--- a/quarto.qmd
+++ b/quarto.qmd
@@ -422,7 +422,7 @@ comma(.12358124331)
 2.  Download `diamond-sizes.qmd` from <https://github.com/hadley/r4ds/tree/main/quarto>.
     Add a section that describes the largest 20 diamonds, including a table that displays their most important attributes.
 
-3.  Modify `diamonds-sizes.qmd` to use `label_comma()` to produce nicely formatted output.
+3.  Modify `diamonds-sizes.qmd` to use `comma()` to produce nicely formatted output.
     Also include the percentage of diamonds that are larger than 2.5 carats.
 
 ## Figures {#sec-figures}
@@ -589,33 +589,37 @@ On subsequent runs, knitr will check to see if the code has changed, and if it h
 The caching system must be used with care, because by default it is based on the code only, not its dependencies.
 For example, here the `processed_data` chunk depends on the `raw-data` chunk:
 
-    `r chunk`{r}
-    #| label: raw-data
+```         
+`r chunk`{r}
+#| label: raw-data
 
-    rawdata <- readr::read_csv("a_very_large_file.csv")
-    `r chunk`
+rawdata <- readr::read_csv("a_very_large_file.csv")
+`r chunk`
 
-    `r chunk`{r}
-    #| label: processed_data
-    #| cache: true
+`r chunk`{r}
+#| label: processed_data
+#| cache: true
 
-    processed_data <- rawdata |> 
-      filter(!is.na(import_var)) |> 
-      mutate(new_variable = complicated_transformation(x, y, z))
-    `r chunk`
+processed_data <- rawdata |> 
+  filter(!is.na(import_var)) |> 
+  mutate(new_variable = complicated_transformation(x, y, z))
+`r chunk`
+```
 
 Caching the `processed_data` chunk means that it will get re-run if the dplyr pipeline is changed, but it won't get rerun if the `read_csv()` call changes.
 You can avoid that problem with the `dependson` chunk option:
 
-    `r chunk`{r}
-    #| label: processed-data
-    #| cache: true
-    #| dependson: "raw-data"
+```         
+`r chunk`{r}
+#| label: processed-data
+#| cache: true
+#| dependson: "raw-data"
 
-    processed_data <- rawdata |> 
-      filter(!is.na(import_var)) |> 
-      mutate(new_variable = complicated_transformation(x, y, z))
-    `r chunk`
+processed_data <- rawdata |> 
+  filter(!is.na(import_var)) |> 
+  mutate(new_variable = complicated_transformation(x, y, z))
+`r chunk`
+```
 
 `dependson` should contain a character vector of *every* chunk that the cached chunk depends on.
 Knitr will update the results for the cached chunk whenever it detects that one of its dependencies have changed.
@@ -626,12 +630,14 @@ This is an arbitrary R expression that will invalidate the cache whenever it cha
 A good function to use is `file.info()`: it returns a bunch of information about the file including when it was last modified.
 Then you can write:
 
-    `r chunk`{r}
-    #| label: raw-data
-    #| cache.extra: file.info("a_very_large_file.csv")
+```         
+`r chunk`{r}
+#| label: raw-data
+#| cache.extra: file.info("a_very_large_file.csv")
 
-    rawdata <- readr::read_csv("a_very_large_file.csv")
-    `r chunk`
+rawdata <- readr::read_csv("a_very_large_file.csv")
+`r chunk`
+```
 
 We've followed the advice of [David Robinson](https://twitter.com/drob/status/738786604731490304) to name these chunks: each chunk is named after the primary object that it creates.
 This makes it easier to understand the `dependson` specification.


### PR DESCRIPTION
- label_comma() is a scales function, and returns a function, not a value. comma() function is created in the previous chunk.
- Insert menu is in the visual editor. If you say Rstudio menu, I look for the first upper menu.
- better to stick to out-width: "70%" notation.
- "By default these dependencies ..." probably forgot to delete.
- !r causes an error. !expr works.