### PR TITLE
Typo: "a new" instead of "an new"

### DIFF
--- a/data-transform.qmd
+++ b/data-transform.qmd
@@ -700,7 +700,7 @@ You get a single row back because dplyr treats all the rows in an ungrouped data
 
 ### `.by`
 
-dplyr 1.1.0 includes an new, experimental, syntax for per-operation grouping, the `.by` argument.
+dplyr 1.1.0 includes a new, experimental, syntax for per-operation grouping, the `.by` argument.
 `group_by()` and `ungroup()` aren't going away, but you can now also use the `.by` argument to group within a single operation:
 
 ```{r}


### PR DESCRIPTION
A simple typo. Thank you!