### PR TITLE
Use dplyr 1.1 'default' parameter in 'case_when()'

### DIFF
--- a/logicals.qmd
+++ b/logicals.qmd
@@ -496,7 +496,7 @@ case_when(
 )
 ```
 
-Use `.default()` if you want to create a "default"/catch all value:
+Use `.default` if you want to create a "default"/catch all value:
 
 ```{r}
 case_when(

--- a/logicals.qmd
+++ b/logicals.qmd
@@ -496,13 +496,13 @@ case_when(
 )
 ```
 
-If you want to create a "default"/catch all value, use `TRUE` on the left hand side:
+Use `.default()` if you want to create a "default"/catch all value:
 
 ```{r}
 case_when(
   x < 0 ~ "-ve",
   x > 0 ~ "+ve",
-  TRUE ~ "???"
+  .default = "???"
 )
 ```
 


### PR DESCRIPTION
`default` is documented in [`case_when()`](https://dplyr.tidyverse.org/reference/case_when.html) and a reference to the  previous `TRUE ~ ` is not included anymore.