### PR TITLE
Fix typo in subsection 4. 1 Introduction of 4. Data Transformation

### DIFF
--- a/data-transform.qmd
+++ b/data-transform.qmd
@@ -10,7 +10,7 @@ source("_common.R")
 
 Visualization is an important tool for generating insight, but it's rare that you get the data in exactly the right form you need to make the graph you want.
 Often you'll need to create some new variables or summaries to answer your questions with your data, or maybe you just want to rename the variables or reorder the observations to make the data a little easier to work with.
-You'll learn how to do all that (and more!) in this chapter, which will introduce you to data transformation using the **dplyr** package and a new dataset on flights that departed New York City in 2013.
+You'll learn how to do all that (and more!) in this chapter, which will introduce you to data transformation using the **dplyr** package and a new dataset on flights that departed from New York City in 2013.
 
 The goal of this chapter is to give you an overview of all the key tools for transforming a data frame.
 We'll start with functions that operate on rows and then columns of a data frame, then circle back to talk more about the pipe, an important tool that you use to combine verbs.


### PR DESCRIPTION
This PR aims to fix a typo in the subsection [`4. 1 Introduction`](https://r4ds.hadley.nz/data-transform.html#introduction) of  `4. Data Transformation`. 