### PR TITLE
Remove numbering from Introduction -- intro.qmd (#1562)

### DIFF
--- a/intro.qmd
+++ b/intro.qmd
@@ -1,4 +1,4 @@
-# Introduction {#sec-intro}
+# Introduction {#sec-intro .unnumbered}
 
 ```{r}
 #| echo: false


### PR DESCRIPTION
This PR addresses the issue I submitted earlier, #1562 .

I followed the [R Markdown cookbook instructions](https://bookdown.org/yihui/rmarkdown-cookbook/unnumbered-sections.html#unnumbered-sections) which note that multiple attributes can be modified in the section heading. Also verified local copy would render the first few chapters (I've been having difficulties with the Arrow chapter). 