### PR TITLE
Fix tiny typo in section "20.2.1 Primary and foreign keys"

### DIFF
--- a/joins.qmd
+++ b/joins.qmd
@@ -42,7 +42,7 @@ You'll also learn how to check that your keys are valid, and what to do if your 
 
 Every join involves a pair of keys: a primary key and a foreign key.
 A **primary key** is a variable or set of variables that uniquely identifies each observation.
-When more than one variable is needed, the key is called a **compound key.** For example, in nycfights13:
+When more than one variable is needed, the key is called a **compound key.** For example, in nycflights13:
 
 -   `airlines` records two pieces of data about each airline: its carrier code and its full name.
     You can identify an airline with its two letter carrier code, making `carrier` the primary key.


### PR DESCRIPTION
This PR aims to fix a tiny typo in the section [20.2.1 Primary and foreign keys](https://r4ds.hadley.nz/joins#primary-and-foreign-keys).