### PR TITLE
Typo in clean_number()

### DIFF
--- a/functions.qmd
+++ b/functions.qmd
@@ -225,7 +225,7 @@ clean_number <- function(x) {
     str_remove_all("%") |> 
     str_remove_all(",") |> 
     str_remove_all(fixed("$")) |> 
-    as.numeric(x)
+    as.numeric()
   if_else(is_pct, num / 100, num)
 }
 


### PR DESCRIPTION
|> as.numeric(x) shouldn't include x as x has been piped in.