### PR TITLE
Update workflow-basics.qmd

### DIFF
--- a/workflow-basics.qmd
+++ b/workflow-basics.qmd
@@ -33,7 +33,7 @@ x <- 3 * 4
 Note that the value of `x` is not printed, it's just stored.
 If you want to view the value, type `x` in the console.
 
-You can **c**ombine multiple elements into a vector with `c()`:
+You can combine multiple elements into a vector with `c()`:
 
 ```{r}
 primes <- c(2, 3, 5, 7, 11, 13)


### PR DESCRIPTION
Letter c in the sentence:

"You can **c**ombine multiple elements into a vector with c():"  has a markdown around which makes it bold in the final book output. 

I think this may be a typo. Thanks so much!