### PR TITLE
logicals.qmd: use better variable names in example

### DIFF
--- a/logicals.qmd
+++ b/logicals.qmd
@@ -360,8 +360,8 @@ That, for example, allows us to see the proportion of flights that were delayed 
 flights |> 
   group_by(year, month, day) |> 
   summarize(
-    all_delayed = mean(dep_delay <= 60, na.rm = TRUE),
-    any_long_delay = sum(arr_delay >= 300, na.rm = TRUE),
+    proportion_delayed = mean(dep_delay <= 60, na.rm = TRUE),
+    count_long_delay = sum(arr_delay >= 300, na.rm = TRUE),
     .groups = "drop"
   )
 ```


### PR DESCRIPTION
The variable names of this example were copied from the previous example, where logical vectors were summarized with `any()` and `all()`. However in the present example the summary is with `sum()` and `mean()`, which was not reflected (updated) in the variable names.