### PR TITLE
Incorrect formula for speed

### DIFF
--- a/data-transform.qmd
+++ b/data-transform.qmd
@@ -261,7 +261,7 @@ For now, we'll stick with basic algebra, which allows us to compute the `gain`, 
 flights |> 
   mutate(
     gain = dep_delay - arr_delay,
-    speed = distance / air_time * 60
+    speed = distance / (air_time / 60)
   )
 ```
 
@@ -274,7 +274,7 @@ We can use the `.before` argument to instead add the variables to the left hand 
 flights |> 
   mutate(
     gain = dep_delay - arr_delay,
-    speed = distance / air_time * 60,
+    speed = distance / (air_time / 60),
     .before = 1
   )
 ```
@@ -289,7 +289,7 @@ For example, we could add the new variables after `day`:
 flights |> 
   mutate(
     gain = dep_delay - arr_delay,
-    speed = distance / air_time * 60,
+    speed = distance / (air_time / 60),
     .after = day
   )
 ```
@@ -472,7 +472,7 @@ For example, imagine that you wanted to find the fastest flights to Houston's IA
 ```{r}
 flights |> 
   filter(dest == "IAH") |> 
-  mutate(speed = distance / air_time * 60) |> 
+  mutate(speed = distance / (air_time / 60)) |> 
   select(year:day, dep_time, carrier, flight, speed) |> 
   arrange(desc(speed))
 ```
@@ -492,7 +492,7 @@ arrange(
         flights, 
         dest == "IAH"
       ),
-      speed = distance / air_time * 60
+      speed = distance / (air_time / 60)
     ),
     year:day, dep_time, carrier, flight, speed
   ),
@@ -506,7 +506,7 @@ Or we could use a bunch of intermediate objects:
 #| results: false
 
 flights1 <- filter(flights, dest == "IAH")
-flights2 <- mutate(flights1, speed = distance / air_time * 60)
+flights2 <- mutate(flights1, speed = distance / (air_time / 60))
 flights3 <- select(flights2, year:day, dep_time, carrier, flight, speed)
 arrange(flights3, desc(speed))
 ```


### PR DESCRIPTION
In several locations speed in the "flights" is defined as "speed = distance / air_time * 60). However, the air_time variable is in minutes. I assume speed needs to be calculated as MPH. Thus, the corrected formula is "speed = distance / (air_time / 60).