### PR TITLE
joins.qmd: fix party-birthday matching condition in text (fixes #1610)

### DIFF
--- a/joins.qmd
+++ b/joins.qmd
@@ -819,7 +819,7 @@ employees <- tibble(
 employees
 ```
 
-And for each employee we want to find the first party date that comes after (or on) their birthday.
+And for each employee we want to find the last party date that comes before (or on) their birthday.
 We can express that with a rolling join:
 
 ```{r}


### PR DESCRIPTION
The updated text now reflects what has been intended, as confirmed from reading on. It's the implementation of the proposed solution in #1610.

Fixes #1610.