### PR TITLE
Fixing some minor errors

### DIFF
--- a/data-tidy.qmd
+++ b/data-tidy.qmd
@@ -209,8 +209,7 @@ billboard |>
 The number of rows is now much lower, indicating that many rows with `NA`s were dropped.
 
 You might also wonder what happens if a song is in the top 100 for more than 76 weeks?
-We can't tell from this data, but you might guess that additional columns `wk77`, `wk78`, ...
-would be added to the dataset.
+We can't tell from this data, but you might guess that additional columns `wk77`, `wk78`, ... would be added to the dataset.
 
 This data is now tidy, but we could make future computation a bit easier by converting values of `week` from character strings to numbers using `mutate()` and `readr::parse_number()`.
 `parse_number()` is a handy function that will extract the first number from a string, ignoring all other text.

--- a/data-tidy.qmd
+++ b/data-tidy.qmd
@@ -209,7 +209,8 @@ billboard |>
 The number of rows is now much lower, indicating that many rows with `NA`s were dropped.
 
 You might also wonder what happens if a song is in the top 100 for more than 76 weeks?
-We can't tell from this data, but you might guess that additional columns `wk77`, `wk78`, ... would be added to the dataset.
+We can't tell from this data, but you might guess that additional columns `wk77`, `wk78`, ...
+would be added to the dataset.
 
 This data is now tidy, but we could make future computation a bit easier by converting values of `week` from character strings to numbers using `mutate()` and `readr::parse_number()`.
 `parse_number()` is a handy function that will extract the first number from a string, ignoring all other text.
@@ -397,7 +398,7 @@ household
 ```
 
 This dataset contains data about five families, with the names and dates of birth of up to two children.
-The new challenge in this dataset is that the column names contain the names of two variables (`dob`, `name)` and the values of another (`child`, with values 1 or 2).
+The new challenge in this dataset is that the column names contain the names of two variables (`dob`, `name`) and the values of another (`child`, with values 1 or 2).
 To solve this problem we again need to supply a vector to `names_to` but this time we use the special `".value"` sentinel; this isn't the name of a variable but a unique value that tells `pivot_longer()` to do something different.
 This overrides the usual `values_to` argument to use the first component of the pivoted column name as a variable name in the output.
 

--- a/data-transform.qmd
+++ b/data-transform.qmd
@@ -164,7 +164,7 @@ flights |>
 ```
 
 This "works", in the sense that it doesn't throw an error, but it doesn't do what you want because `|` first checks the condition `month == 1` and then checks the condition `2`, which is not a sensible condition to check.
-We'll learn more about what's happening here and why in @sec-boolean-operations.
+We'll learn more about what's happening here and why in @sec-order-operations-boolean.
 
 ### `arrange()`
 

--- a/logicals.qmd
+++ b/logicals.qmd
@@ -248,7 +248,7 @@ A missing value in a logical vector means that the value could either be `TRUE` 
 However, `NA | FALSE` is `NA` because we don't know if `NA` is `TRUE` or `FALSE`.
 Similar reasoning applies with `NA & FALSE`.
 
-### Order of operations
+### Order of operations {#sec-order-operations-boolean}
 
 Note that the order of operations doesn't work like English.
 Take the following code that finds all flights that departed in November or December:


### PR DESCRIPTION
The first commit fixes a minor typo in data-tidy chapter.
The second commit fixes a misleading reference in chapter data-transform. Closes issue #1656  