### PR TITLE
Suggest/layers.qmd shape descriptions in fig-alt, etc.

### DIFF
--- a/layers.qmd
+++ b/layers.qmd
@@ -792,7 +792,7 @@ Each colored rectangle represents a combination of `drv` and `class`.
 #|   Segmented bar chart of drive types of cars, where each bar is filled with 
 #|   colors for the classes of cars. Heights of the bars correspond to the 
 #|   number of cars in each drive category, and heights of the colored 
-#|   segments are proportional to the number of cars with a given class 
+#|   segments represent the number of cars with a given class 
 #|   level within a given drive type level.
 
 ggplot(mpg, aes(x = drv, fill = class)) + 
@@ -811,9 +811,9 @@ If you don't want a stacked bar chart, you can use one of three other options: `
     #| fig-width: 4
     #| fig-alt: |
     #|   Segmented bar chart of drive types of cars, where each bar is filled with 
-    #|   colors for the classes of cars. Heights of the bars correspond to the 
-    #|   number of cars in each drive category, and heights of the colored 
-    #|   segments are proportional to the number of cars with a given class 
+    #|   colors for the classes of cars. 
+    #|   Heights of the colored 
+    #|   segments represent the number of cars with a given class 
     #|   level within a given drive type level. However the segments overlap. In 
     #|   the first plot the bars are filled with transparent colors
     #|   and in the second plot they are only outlined with color.


### PR DESCRIPTION
How about changing fig-alt descriptions of 26 shapes to those matching character strings, which can be used to set "shape"?
Other suggestions are mostly typos and careless mistakes.