### PR TITLE
Correct numeric precision comment

### DIFF
--- a/logicals.qmd
+++ b/logicals.qmd
@@ -100,7 +100,7 @@ x == c(1, 2)
 ```
 
 What's going on?
-Computers store numbers with a fixed number of decimal places so there's no way to exactly represent 1/49 or `sqrt(2)` and subsequent computations will be very slightly off.
+Computers store numbers with finite precision so there's no way to exactly represent 1/49 or `sqrt(2)` and subsequent computations will be very slightly off.
 We can see the exact values by calling `print()` with the `digits`[^logicals-1] argument:
 
 [^logicals-1]: R normally calls print for you (i.e. `x` is a shortcut for `print(x)`), but calling it explicitly is useful if you want to provide other arguments.


### PR DESCRIPTION
It's not correct to say R uses numbers with "a fixed number of decimal places"; that implies fixed-point arithmetic, but R uses floating-point arithmetic, where the number of decimal places depends on the scale of the variable. Numbers near 0 are represented with more decimal places than very large numbers.

It's fair to say the precision is finite, and that's the real problem, as the precision isn't enough to represent the numbers exactly (and can't be, for sqrt(2)).