### PR TITLE
Improving missing values operation explanation in boolean algebra section

### DIFF
--- a/logicals.qmd
+++ b/logicals.qmd
@@ -246,7 +246,8 @@ A missing value in a logical vector means that the value could either be `TRUE` 
 `TRUE | TRUE` and `FALSE | TRUE` are both `TRUE` because at least one of them is `TRUE`.
 `NA | TRUE` must also be `TRUE` because `NA` can either be `TRUE` or `FALSE`.
 However, `NA | FALSE` is `NA` because we don't know if `NA` is `TRUE` or `FALSE`.
-Similar reasoning applies with `NA & FALSE`.
+Similar reasoning applies `&` considering that both conditions most be fulfilled.
+Therefore `NA & TRUE` is `NA` because `NA` can either be `TRUE` or `FALSE` and `NA & FALSE` is `FALSE` beacuse at least one of the conditions is `FLASE`.
 
 ### Order of operations {#sec-order-operations-boolean}
 

--- a/logicals.qmd
+++ b/logicals.qmd
@@ -246,7 +246,7 @@ A missing value in a logical vector means that the value could either be `TRUE` 
 `TRUE | TRUE` and `FALSE | TRUE` are both `TRUE` because at least one of them is `TRUE`.
 `NA | TRUE` must also be `TRUE` because `NA` can either be `TRUE` or `FALSE`.
 However, `NA | FALSE` is `NA` because we don't know if `NA` is `TRUE` or `FALSE`.
-Similar reasoning applies `&` considering that both conditions must be fulfilled.
+Similar reasoning applies for `&` considering that both conditions must be fulfilled.
 Therefore `NA & TRUE` is `NA` because `NA` can either be `TRUE` or `FALSE` and `NA & FALSE` is `FALSE` because at least one of the conditions is `FALSE`.
 
 ### Order of operations {#sec-order-operations-boolean}

--- a/logicals.qmd
+++ b/logicals.qmd
@@ -246,8 +246,8 @@ A missing value in a logical vector means that the value could either be `TRUE` 
 `TRUE | TRUE` and `FALSE | TRUE` are both `TRUE` because at least one of them is `TRUE`.
 `NA | TRUE` must also be `TRUE` because `NA` can either be `TRUE` or `FALSE`.
 However, `NA | FALSE` is `NA` because we don't know if `NA` is `TRUE` or `FALSE`.
-Similar reasoning applies `&` considering that both conditions most be fulfilled.
-Therefore `NA & TRUE` is `NA` because `NA` can either be `TRUE` or `FALSE` and `NA & FALSE` is `FALSE` beacuse at least one of the conditions is `FLASE`.
+Similar reasoning applies `&` considering that both conditions must be fulfilled.
+Therefore `NA & TRUE` is `NA` because `NA` can either be `TRUE` or `FALSE` and `NA & FALSE` is `FALSE` because at least one of the conditions is `FALSE`.
 
 ### Order of operations {#sec-order-operations-boolean}
 


### PR DESCRIPTION
Previous explanation

> To understand what's going on, think about `NA | TRUE` (`NA` or `TRUE`). A missing value in a logical vector means that the value could either be `TRUE` or `FALSE`. `TRUE | TRUE` and `FALSE | TRUE` are both `TRUE` because at least one of them is `TRUE`. `NA | TRUE` must also be `TRUE` because `NA` can either be `TRUE` or `FALSE`. However, `NA | FALSE` is `NA` because we don't know if `NA` is `TRUE` or `FALSE`. Similar reasoning applies with `NA & FALSE`

The last sentence of previous explanation implies that `NA & FALSE` returns `NA` as `NA | FALSE`, explained in previous sentence. Therefore a more detailed explanation explaining how the similar reasoning is applied when using `&` but taking into consideration that both conditions must be fulfilled.

> To understand what's going on, think about `NA | TRUE` (`NA` or `TRUE`). A missing value in a logical vector means that the value could either be `TRUE` or `FALSE`. `TRUE | TRUE` and `FALSE | TRUE` are both `TRUE` because at least one of them is `TRUE`. `NA | TRUE` must also be `TRUE` because `NA` can either be `TRUE` or `FALSE`. However, `NA | FALSE` is `NA` because we don't know if `NA` is `TRUE` or `FALSE`. Similar reasoning applies for `&` considering that both conditions must be fulfilled. Therefore `NA & TRUE` is `NA` because `NA` can either be `TRUE` or `FALSE` and `NA & FALSE` is `FALSE` because at least one of the conditions is `FALSE`.