### PR TITLE
Correct display of embracing operator

### DIFF
--- a/functions.qmd
+++ b/functions.qmd
@@ -351,7 +351,7 @@ But you'll often also repeat the verbs themselves, particularly within a large p
 When you notice yourself copying and pasting multiple verbs multiple times, you might think about writing a data frame function.
 Data frame functions work like dplyr verbs: they take a data frame as the first argument, some extra arguments that say what to do with it, and return a data frame or a vector.
 
-To let you write a function that uses dplyr verbs, we'll first introduce you to the challenge of indirection and how you can overcome it with embracing, `{{ }}`.
+To let you write a function that uses dplyr verbs, we'll first introduce you to the challenge of indirection and how you can overcome it with embracing, `{{{ }}}`.
 With this theory under your belt, we'll then show you a bunch of examples to illustrate what you might do with it.
 
 ### Indirection and tidy evaluation
@@ -398,11 +398,11 @@ The downside of tidy evaluation comes when we want to wrap up repeated tidyverse
 Here we need some way to tell `group_by()` and `summarize()` not to treat `group_var` and `mean_var` as the name of the variables, but instead look inside them for the variable we actually want to use.
 
 Tidy evaluation includes a solution to this problem called **embracing** 🤗.
-Embracing a variable means to wrap it in braces so (e.g.) `var` becomes `{{ var }}`.
+Embracing a variable means to wrap it in braces so (e.g.) `var` becomes `{{{ var }}}`.
 Embracing a variable tells dplyr to use the value stored inside the argument, not the argument as the literal variable name.
-One way to remember what's happening is to think of `{{ }}` as looking down a tunnel --- `{{ var }}` will make a dplyr function look inside of `var` rather than looking for a variable called `var`.
+One way to remember what's happening is to think of `{{{ }}}` as looking down a tunnel --- `{{{ var }}}` will make a dplyr function look inside of `var` rather than looking for a variable called `var`.
 
-So to make `grouped_mean()` work, we need to surround `group_var` and `mean_var` with `{{ }}`:
+So to make `grouped_mean()` work, we need to surround `group_var` and `mean_var` with `{{{ }}}`:
 
 ```{r}
 grouped_mean <- function(df, group_var, mean_var) {
@@ -782,7 +782,7 @@ rlang is a low-level package that's used by just about every other package in th
 
 To solve the labeling problem we can use `rlang::englue()`.
 This works similarly to `str_glue()`, so any value wrapped in `{ }` will be inserted into the string.
-But it also understands `{{ }}`, which automatically inserts the appropriate variable name:
+But it also understands `{{{ }}}`, which automatically inserts the appropriate variable name:
 
 ```{r}
 #| fig-alt: |
@@ -861,7 +861,7 @@ density <- function(color, facets, binwidth = 0.1) {
 }
 ```
 
-As you can see we recommend putting extra spaces inside of `{{ }}`.
+As you can see we recommend putting extra spaces inside of `{{{ }}}`.
 This makes it very obvious that something unusual is happening.
 
 ### Exercises


### PR DESCRIPTION
Quarto supports inline code using the backtick operator [1], using backticks and curly quotes to specify the engine. Because of this, `{{ }}` is apparently parsed as inline code and renders as `{ }`. An extra level of curly braces must be added to display the embracing operator in the text.

(I suppose this could also be considered a Quarto bug, since their parser is treating this as inline code when it clearly isn't. But this is an easy solution.)

[1]: https://quarto.org/docs/computations/inline-code.html