### PR TITLE
Edit typo in EDA chapter, summaries -> summarizes

### DIFF
--- a/EDA.qmd
+++ b/EDA.qmd
@@ -597,7 +597,7 @@ ggplot(smaller, aes(x = carat, y = price)) +
 ```
 
 `cut_width(x, width)`, as used above, divides `x` into bins of width `width`.
-By default, boxplots look roughly the same (apart from number of outliers) regardless of how many observations there are, so it's difficult to tell that each boxplot summaries a different number of points.
+By default, boxplots look roughly the same (apart from number of outliers) regardless of how many observations there are, so it's difficult to tell that each boxplot summarizes a different number of points.
 One way to show that is to make the width of the boxplot proportional to the number of points with `varwidth = TRUE`.
 
 #### Exercises


### PR DESCRIPTION
I edited the typo in this sentence: "so it’s difficult to tell that each boxplot summaries a different number of points"