### PR TITLE
Edit a typo in the logicals chapter

### DIFF
--- a/logicals.qmd
+++ b/logicals.qmd
@@ -437,7 +437,7 @@ There's an optional fourth argument, `missing` which will be used if the input i
 if_else(x > 0, "+ve", "-ve", "???")
 ```
 
-You can also use vectors for the the `true` and `false` arguments.
+You can also use vectors for the `true` and `false` arguments.
 For example, this allows us to create a minimal implementation of `abs()`:
 
 ```{r}


### PR DESCRIPTION
Yet another typo. This time I removed "the" from the double "the the"