### PR TITLE
fix: typo in vector functions

### DIFF
--- a/functions.qmd
+++ b/functions.qmd
@@ -59,7 +59,7 @@ df <- tibble(
 df |> mutate(
   a = (a - min(a, na.rm = TRUE)) / 
     (max(a, na.rm = TRUE) - min(a, na.rm = TRUE)),
-  b = (b - min(a, na.rm = TRUE)) / 
+  b = (b - min(b, na.rm = TRUE)) / 
     (max(b, na.rm = TRUE) - min(b, na.rm = TRUE)),
   c = (c - min(c, na.rm = TRUE)) / 
     (max(c, na.rm = TRUE) - min(c, na.rm = TRUE)),


### PR DESCRIPTION
I believe there's a typo in the example in the vector functions.