### PR TITLE
Modified min_rank() example

### DIFF
--- a/numbers.qmd
+++ b/numbers.qmd
@@ -403,7 +403,7 @@ dplyr provides a number of ranking functions inspired by SQL, but you should alw
 It uses the typical method for dealing with ties, e.g., 1st, 2nd, 2nd, 4th.
 
 ```{r}
-x <- c(1, 2, 2, 3, 4, NA)
+x <- c(1, 5, 5, 17, 22, NA)
 min_rank(x)
 ```
 


### PR DESCRIPTION
Changed c(1, 2, 2, 3, 4, NA) to c(1, 5, 5, 17, 22, NA), which more clearly illustrates that the rank is returned, not the element. Since the result of the example is 1  2  2  4  5 NA (which closely resembles the result if pmin() was used), this was not immediately obvious on first glance.