### PR TITLE
Improve description of readr heuristics on data-import.qmd

### DIFF
--- a/data-import.qmd
+++ b/data-import.qmd
@@ -276,7 +276,7 @@ Finally, we'll mention a few general strategies that are useful if readr is fail
 ### Guessing types
 
 readr uses a heuristic to figure out the column types.
-For each column, it pulls the values of 1,000[^data-import-2] rows spaced evenly from the first row to the last, ignoring missing values.
+For each column, it pulls the values of 1,000 rows[^data-import-2] spaced evenly from the first row to the last, ignoring missing values.
 It then works through the following questions:
 
 [^data-import-2]: You can override the default of 1000 with the `guess_max` argument.


### PR DESCRIPTION
I read "1,000^2" and it wasn't obvious that the "^2" was a citation, and instead I thought that it was an exponent. It was confusing, and it was only when I hovered over the 2 that I realized what was happening. To solve this, I simply moved the "^2" to the next word, so that the "2" is commenting on the broader idea of "1,000 rows".