### PR TITLE
Clarify how to override the default type-guessing heuristic in data-i…

### DIFF
--- a/data-import.qmd
+++ b/data-import.qmd
@@ -361,7 +361,7 @@ readr provides a total of nine column types for you to use:
 -   `col_number()` is a permissive numeric parser that will ignore non-numeric components, and is particularly useful for currencies. You'll learn more about it in @sec-numbers.
 -   `col_skip()` skips a column so it's not included in the result, which can be useful for speeding up reading the data if you have a large CSV file and you only want to use some of the columns.
 
-It's also possible to override the default column by switching from `list()` to `cols()` and specifying `.default`:
+It's also possible to override the default heuristic that guesses types by switching from `list()` to `cols()` and specifying `.default`:
 
 ```{r}
 another_csv <- "


### PR DESCRIPTION
…mport.qmd

The phrase took time to understand, and —unless I missed something about the "default column"—, I believe the idea here is that the _default algorithm_ for type-guessing is the one that's overridden by the "cols(.default" function and parameter.